### PR TITLE
[test] Import fixtures that mirror Flow tests upstream.

### DIFF
--- a/test/fixtures/type-generator/conditional.golden.ts
+++ b/test/fixtures/type-generator/conditional.golden.ts
@@ -1,0 +1,13 @@
+import { FragmentReference } from "relay-runtime";
+export type ConditionField$ref = FragmentReference;
+export interface ConditionField {
+  readonly id?: string;
+  readonly $refType: ConditionField$ref;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type NestedCondition$ref = FragmentReference;
+export interface NestedCondition {
+  readonly id?: string;
+  readonly $refType: NestedCondition$ref;
+}

--- a/test/fixtures/type-generator/conditional.input.graphql
+++ b/test/fixtures/type-generator/conditional.input.graphql
@@ -1,0 +1,9 @@
+fragment ConditionField on Node {
+  id @include(if: $condition)
+}
+
+fragment NestedCondition on Node {
+  ... @include(if: $condition) {
+    id
+  }
+}

--- a/test/fixtures/type-generator/fragment-spread.golden.ts
+++ b/test/fixtures/type-generator/fragment-spread.golden.ts
@@ -1,0 +1,37 @@
+type OtherFragment$ref = any;
+type PictureFragment$ref = any;
+type UserFrag1$ref = any;
+type UserFrag2$ref = any;
+import { FragmentReference } from "relay-runtime";
+export type FragmentSpread$ref = FragmentReference;
+export interface FragmentSpread {
+  readonly id: string;
+  readonly justFrag: {
+    readonly __fragments: PictureFragment$ref;
+  } | null;
+  readonly fragAndField: {
+    readonly uri: string | null;
+    readonly __fragments: PictureFragment$ref;
+  } | null;
+  readonly __fragments: OtherFragment$ref & UserFrag1$ref & UserFrag2$ref;
+  readonly $refType: FragmentSpread$ref;
+}
+
+type PageFragment$ref = any;
+import { FragmentReference } from "relay-runtime";
+export type ConcreateTypes$ref = FragmentReference;
+export interface ConcreateTypes {
+  readonly actor: {
+    readonly __typename: "Page";
+    readonly id: string;
+    readonly __fragments: PageFragment$ref;
+  } | {
+    readonly __typename: "User";
+    readonly name: string | null;
+  } | {
+    // This will never be "%other", but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  } | null;
+  readonly $refType: ConcreateTypes$ref;
+}

--- a/test/fixtures/type-generator/fragment-spread.input.graphql
+++ b/test/fixtures/type-generator/fragment-spread.input.graphql
@@ -1,0 +1,28 @@
+fragment FragmentSpread on Node {
+  id
+  ...OtherFragment
+  justFrag: profilePicture {
+    ...PictureFragment
+  }
+  fragAndField: profilePicture {
+    uri
+    ...PictureFragment
+  }
+  ... on User {
+    ...UserFrag1
+    ...UserFrag2
+  }
+}
+
+fragment ConcreateTypes on Viewer {
+  actor {
+    __typename
+    ... on Page {
+      id
+      ...PageFragment
+    }
+    ... on User {
+      name
+    }
+  }
+}

--- a/test/fixtures/type-generator/inline-fragment.golden.ts
+++ b/test/fixtures/type-generator/inline-fragment.golden.ts
@@ -1,0 +1,49 @@
+import { FragmentReference } from "relay-runtime";
+export type InlineFragment$ref = FragmentReference;
+export interface InlineFragment {
+  readonly id: string;
+  readonly name?: string | null;
+  readonly message?: {
+    readonly text: string | null;
+  } | null;
+  readonly $refType: InlineFragment$ref;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type InlineFragmentWithOverlappingFields$ref = FragmentReference;
+export interface InlineFragmentWithOverlappingFields {
+  readonly hometown?: {
+    readonly id: string;
+    readonly name: string | null;
+    readonly message?: {
+      readonly text: string | null;
+    } | null;
+  } | null;
+  readonly name?: string | null;
+  readonly $refType: InlineFragmentWithOverlappingFields$ref;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type InlineFragmentConditionalID$ref = FragmentReference;
+export interface InlineFragmentConditionalID {
+  readonly id?: string;
+  readonly name?: string | null;
+  readonly $refType: InlineFragmentConditionalID$ref;
+}
+
+type SomeFragment$ref = any;
+import { FragmentReference } from "relay-runtime";
+export type InlineFragmentKitchenSink$ref = FragmentReference;
+export interface InlineFragmentKitchenSink {
+  readonly actor: {
+    readonly id: string;
+    readonly profilePicture: {
+      readonly uri: string | null;
+      readonly width?: number | null;
+      readonly height?: number | null;
+    } | null;
+    readonly name?: string | null;
+    readonly __fragments: SomeFragment$ref;
+  } | null;
+  readonly $refType: InlineFragmentKitchenSink$ref;
+}

--- a/test/fixtures/type-generator/inline-fragment.input.graphql
+++ b/test/fixtures/type-generator/inline-fragment.input.graphql
@@ -1,0 +1,60 @@
+fragment InlineFragment on Node {
+  id
+  ... on Actor {
+    id
+    name
+  }
+  ... on User {
+    message {
+      text
+    }
+  }
+}
+
+fragment InlineFragmentWithOverlappingFields on Actor {
+  ... on User {
+    hometown {
+      id
+      name
+    }
+  }
+  ... on Page {
+    name
+    hometown {
+      id
+      message {
+        text
+      }
+    }
+  }
+}
+
+fragment InlineFragmentConditionalID on Node {
+  ... on Actor {
+    id # nullable since it's conditional
+    name
+  }
+}
+
+fragment InlineFragmentKitchenSink on Story {
+  actor {
+    id
+    profilePicture {
+      uri
+    }
+    ... on User {
+      id
+      name
+      ...SomeFragment
+      profilePicture {
+        width
+      }
+    }
+    ... on Page {
+      profilePicture {
+        uri
+        height
+      }
+    }
+  }
+}

--- a/test/fixtures/type-generator/linked-field.golden.ts
+++ b/test/fixtures/type-generator/linked-field.golden.ts
@@ -1,0 +1,31 @@
+import { FragmentReference } from "relay-runtime";
+export type LinkedField$ref = FragmentReference;
+export interface LinkedField {
+  readonly profilePicture: {
+    readonly uri: string | null;
+    readonly width: number | null;
+    readonly height: number | null;
+  } | null;
+  readonly hometown: {
+    readonly id: string;
+    readonly profilePicture: {
+      readonly uri: string | null;
+    } | null;
+  } | null;
+  readonly actor: {
+    readonly id: string;
+  } | null;
+  readonly $refType: LinkedField$ref;
+}
+
+export interface UnionTypeTestVariables {}
+export interface UnionTypeTestResponse {
+  readonly neverNode: {
+    readonly __typename: "FakeNode";
+    readonly id: string;
+  } | {
+    // This will never be "%other", but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  } | null;
+}

--- a/test/fixtures/type-generator/linked-field.input.graphql
+++ b/test/fixtures/type-generator/linked-field.input.graphql
@@ -1,0 +1,27 @@
+fragment LinkedField on User {
+  profilePicture {
+    uri
+    width
+    height
+  }
+  hometown {
+    # object
+    id
+    profilePicture {
+      uri
+    }
+  }
+  actor {
+    # interface
+    id
+  }
+}
+
+query UnionTypeTest {
+  neverNode {
+    __typename
+    ... on FakeNode {
+      id
+    }
+  }
+}

--- a/test/fixtures/type-generator/mutation-input-has-array.golden.ts
+++ b/test/fixtures/type-generator/mutation-input-has-array.golden.ts
@@ -1,0 +1,13 @@
+export interface InputHasArrayVariables {
+  input?: {
+    clientMutationId?: string | null;
+    storyIds?: ReadonlyArray<string | null> | null;
+  } | null;
+}
+export interface InputHasArrayResponse {
+  readonly viewerNotificationsUpdateAllSeenState: {
+    readonly stories: ReadonlyArray<{
+      readonly actorCount: number | null;
+    } | null> | null;
+  } | null;
+}

--- a/test/fixtures/type-generator/mutation-input-has-array.input.graphql
+++ b/test/fixtures/type-generator/mutation-input-has-array.input.graphql
@@ -1,0 +1,7 @@
+mutation InputHasArray($input: UpdateAllSeenStateInput) {
+  viewerNotificationsUpdateAllSeenState(input: $input) {
+    stories {
+      actorCount
+    }
+  }
+}

--- a/test/fixtures/type-generator/mutation.golden.ts
+++ b/test/fixtures/type-generator/mutation.golden.ts
@@ -1,0 +1,19 @@
+export interface CommentCreateMutationVariables {
+  input: {
+    clientMutationId?: string | null;
+    feedbackId?: string | null;
+  };
+  first?: number | null;
+  orderBy?: ReadonlyArray<string> | null;
+}
+export interface CommentCreateMutationResponse {
+  readonly commentCreate: {
+    readonly comment: {
+      readonly id: string;
+      readonly name: string | null;
+      readonly friends: {
+        readonly count: number | null;
+      } | null;
+    } | null;
+  } | null;
+}

--- a/test/fixtures/type-generator/mutation.input.graphql
+++ b/test/fixtures/type-generator/mutation.input.graphql
@@ -1,0 +1,15 @@
+mutation CommentCreateMutation(
+  $input: CommentCreateInput!
+  $first: Int
+  $orderBy: [String!]
+) {
+  commentCreate(input: $input) {
+    comment {
+      id
+      name
+      friends(first: $first, orderby: $orderBy) {
+        count
+      }
+    }
+  }
+}

--- a/test/fixtures/type-generator/plural-fragment.golden.ts
+++ b/test/fixtures/type-generator/plural-fragment.golden.ts
@@ -1,0 +1,6 @@
+import { FragmentReference } from "relay-runtime";
+export type PluralFragment$ref = FragmentReference;
+export type PluralFragment = ReadonlyArray<{
+  readonly id: string;
+  readonly $refType: PluralFragment$ref;
+}>;

--- a/test/fixtures/type-generator/plural-fragment.input.graphql
+++ b/test/fixtures/type-generator/plural-fragment.input.graphql
@@ -1,0 +1,3 @@
+fragment PluralFragment on Node @relay(plural: true) {
+  id
+}

--- a/test/fixtures/type-generator/roots.golden.ts
+++ b/test/fixtures/type-generator/roots.golden.ts
@@ -1,0 +1,43 @@
+export interface ExampleQueryVariables {
+  id: string;
+}
+export interface ExampleQueryResponse {
+  readonly node: {
+    readonly id: string;
+  } | null;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type ExampleFragment$ref = FragmentReference;
+export interface ExampleFragment {
+  readonly id: string;
+  readonly $refType: ExampleFragment$ref;
+}
+
+export interface TestMutationVariables {
+  input: {
+    clientMutationId?: string | null;
+    feedbackId?: string | null;
+  };
+}
+export interface TestMutationResponse {
+  readonly commentCreate: {
+    readonly comment: {
+      readonly id: string;
+    } | null;
+  } | null;
+}
+
+export interface TestSubscriptionVariables {
+  input?: {
+    clientMutationId?: string | null;
+    feedbackId?: string | null;
+  } | null;
+}
+export interface TestSubscriptionResponse {
+  readonly feedbackLikeSubscribe: {
+    readonly feedback: {
+      readonly id: string;
+    } | null;
+  } | null;
+}

--- a/test/fixtures/type-generator/roots.input.graphql
+++ b/test/fixtures/type-generator/roots.input.graphql
@@ -1,0 +1,25 @@
+query ExampleQuery($id: ID!) {
+  node(id: $id) {
+    id
+  }
+}
+
+fragment ExampleFragment on User {
+  id
+}
+
+mutation TestMutation($input: CommentCreateInput!) {
+  commentCreate(input: $input) {
+    comment {
+      id
+    }
+  }
+}
+
+subscription TestSubscription($input: FeedbackLikeInput) {
+  feedbackLikeSubscribe(input: $input) {
+    feedback {
+      id
+    }
+  }
+}

--- a/test/fixtures/type-generator/scalar-field.golden.ts
+++ b/test/fixtures/type-generator/scalar-field.golden.ts
@@ -1,0 +1,17 @@
+export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value";
+import { FragmentReference } from "relay-runtime";
+export type ScalarField$ref = FragmentReference;
+export interface ScalarField {
+  readonly id: string;
+  readonly name: string | null;
+  readonly websites: ReadonlyArray<string | null> | null;
+  readonly traits: ReadonlyArray<PersonalityTraits | null> | null;
+  readonly aliasedLinkedField: {
+    readonly aliasedField: number | null;
+  } | null;
+  readonly screennames: ReadonlyArray<{
+    readonly name: string | null;
+    readonly service: string | null;
+  } | null> | null;
+  readonly $refType: ScalarField$ref;
+}

--- a/test/fixtures/type-generator/scalar-field.input.graphql
+++ b/test/fixtures/type-generator/scalar-field.input.graphql
@@ -1,0 +1,13 @@
+fragment ScalarField on User {
+  id
+  name
+  websites
+  traits
+  aliasedLinkedField: birthdate {
+    aliasedField: year
+  }
+  screennames {
+    name
+    service
+  }
+}

--- a/test/fixtures/type-generator/typename-on-union.golden.ts
+++ b/test/fixtures/type-generator/typename-on-union.golden.ts
@@ -1,0 +1,73 @@
+import { FragmentReference } from "relay-runtime";
+export type TypenameInside$ref = FragmentReference;
+export type TypenameInside = {
+  readonly __typename: "User";
+  readonly firstName: string | null;
+  readonly $refType: TypenameInside$ref;
+} | {
+  readonly __typename: "Page";
+  readonly username: string | null;
+  readonly $refType: TypenameInside$ref;
+} | {
+  // This will never be "%other", but we need some
+  // value in case none of the concrete values match.
+  readonly __typename: "%other";
+  readonly $refType: TypenameInside$ref;
+};
+
+import { FragmentReference } from "relay-runtime";
+export type TypenameOutside$ref = FragmentReference;
+export type TypenameOutside = {
+  readonly __typename: "User";
+  readonly firstName: string | null;
+  readonly $refType: TypenameOutside$ref;
+} | {
+  readonly __typename: "Page";
+  readonly username: string | null;
+  readonly $refType: TypenameOutside$ref;
+} | {
+  // This will never be "%other", but we need some
+  // value in case none of the concrete values match.
+  readonly __typename: "%other";
+  readonly $refType: TypenameOutside$ref;
+};
+
+import { FragmentReference } from "relay-runtime";
+export type TypenameOutsideWithAbstractType$ref = FragmentReference;
+export interface TypenameOutsideWithAbstractType {
+  readonly __typename: string;
+  readonly username?: string | null;
+  readonly address?: {
+    readonly city: string | null;
+    readonly country: string | null;
+    readonly street?: string | null;
+  } | null;
+  readonly firstName?: string | null;
+  readonly $refType: TypenameOutsideWithAbstractType$ref;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type TypenameWithoutSpreads$ref = FragmentReference;
+export interface TypenameWithoutSpreads {
+  readonly firstName: string | null;
+  readonly __typename: "User";
+  readonly $refType: TypenameWithoutSpreads$ref;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type TypenameWithoutSpreadsAbstractType$ref = FragmentReference;
+export interface TypenameWithoutSpreadsAbstractType {
+  readonly __typename: string;
+  readonly id: string;
+  readonly $refType: TypenameWithoutSpreadsAbstractType$ref;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type TypenameWithCommonSelections$ref = FragmentReference;
+export interface TypenameWithCommonSelections {
+  readonly __typename: string;
+  readonly name: string | null;
+  readonly firstName?: string | null;
+  readonly username?: string | null;
+  readonly $refType: TypenameWithCommonSelections$ref;
+}

--- a/test/fixtures/type-generator/typename-on-union.input.graphql
+++ b/test/fixtures/type-generator/typename-on-union.input.graphql
@@ -1,0 +1,60 @@
+fragment TypenameInside on Actor {
+  ... on User {
+    __typename
+    firstName
+  }
+  ... on Page {
+    __typename
+    username
+  }
+}
+
+fragment TypenameOutside on Actor {
+  __typename
+  ... on User {
+    firstName
+  }
+  ... on Page {
+    username
+  }
+}
+
+fragment TypenameOutsideWithAbstractType on Node {
+  __typename
+  ... on User {
+    firstName
+    address {
+      street # only here
+      city # common
+    }
+  }
+  ... on Actor {
+    username
+    address {
+      city # common
+      country # only here
+    }
+  }
+}
+
+fragment TypenameWithoutSpreads on User {
+  __typename
+  firstName
+}
+
+fragment TypenameWithoutSpreadsAbstractType on Node {
+  __typename
+  id
+}
+
+
+fragment TypenameWithCommonSelections on Actor {
+  __typename
+  name
+  ... on User {
+    firstName
+  }
+  ... on Page {
+    username
+  }
+}

--- a/test/fixtures/type-generator/unmasked-fragment-spreads.golden.ts
+++ b/test/fixtures/type-generator/unmasked-fragment-spreads.golden.ts
@@ -1,0 +1,36 @@
+import { PhotoFragment$ref } from "PhotoFragment.graphql";
+import { FragmentReference } from "relay-runtime";
+export type UserProfile$ref = FragmentReference;
+export interface UserProfile {
+  readonly profilePicture: {
+    readonly uri: string | null;
+    readonly width: number | null;
+    readonly height: number | null;
+    readonly __fragments: PhotoFragment$ref;
+  } | null;
+  readonly $refType: UserProfile$ref;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type PhotoFragment$ref = FragmentReference;
+export interface PhotoFragment {
+  readonly uri: string | null;
+  readonly width: number | null;
+  readonly $refType: PhotoFragment$ref;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type RecursiveFragment$ref = FragmentReference;
+export interface RecursiveFragment {
+  readonly uri: string | null;
+  readonly width: number | null;
+  readonly $refType: RecursiveFragment$ref;
+}
+
+import { FragmentReference } from "relay-runtime";
+export type AnotherRecursiveFragment$ref = FragmentReference;
+export interface AnotherRecursiveFragment {
+  readonly uri: string | null;
+  readonly height: number | null;
+  readonly $refType: AnotherRecursiveFragment$ref;
+}

--- a/test/fixtures/type-generator/unmasked-fragment-spreads.input.graphql
+++ b/test/fixtures/type-generator/unmasked-fragment-spreads.input.graphql
@@ -1,0 +1,26 @@
+fragment UserProfile on User {
+  profilePicture(size: $ProfilePicture_SIZE) {
+    ...PhotoFragment @relay(mask: false)
+
+    # duplicated field should be merged
+    ...AnotherRecursiveFragment @relay(mask: false)
+
+    # Compose child fragment
+    ...PhotoFragment
+  }
+}
+
+fragment PhotoFragment on Image {
+  uri
+  ...RecursiveFragment @relay(mask: false)
+}
+
+fragment RecursiveFragment on Image {
+  uri
+  width
+}
+
+fragment AnotherRecursiveFragment on Image {
+  uri
+  height
+}


### PR DESCRIPTION
I took the liberty to copy the test fixtures I made while working on my Babel7 approach and mirror exactly the Flow ones. I’m sure they’ll need some adjusting for how we’ll be defining types, but could be helpful as a guidance.