### PR TITLE
Fix property optionalism within Input Objects

### DIFF
--- a/example/ts/__relay_artifacts__/AddTodoMutation.graphql.ts
+++ b/example/ts/__relay_artifacts__/AddTodoMutation.graphql.ts
@@ -3,8 +3,8 @@
 import { ConcreteRequest } from "relay-runtime";
 export type AddTodoMutationVariables = {
     readonly input: {
-        readonly text?: string;
-        readonly clientMutationId: string | null;
+        readonly text: string;
+        readonly clientMutationId?: string | null;
     };
 };
 export type AddTodoMutationResponse = {

--- a/example/ts/__relay_artifacts__/ChangeTodoStatusMutation.graphql.ts
+++ b/example/ts/__relay_artifacts__/ChangeTodoStatusMutation.graphql.ts
@@ -3,9 +3,9 @@
 import { ConcreteRequest } from "relay-runtime";
 export type ChangeTodoStatusMutationVariables = {
     readonly input: {
-        readonly complete?: boolean;
-        readonly id?: string;
-        readonly clientMutationId: string | null;
+        readonly complete: boolean;
+        readonly id: string;
+        readonly clientMutationId?: string | null;
     };
 };
 export type ChangeTodoStatusMutationResponse = {

--- a/example/ts/__relay_artifacts__/MarkAllTodosMutation.graphql.ts
+++ b/example/ts/__relay_artifacts__/MarkAllTodosMutation.graphql.ts
@@ -3,8 +3,8 @@
 import { ConcreteRequest } from "relay-runtime";
 export type MarkAllTodosMutationVariables = {
     readonly input: {
-        readonly complete?: boolean;
-        readonly clientMutationId: string | null;
+        readonly complete: boolean;
+        readonly clientMutationId?: string | null;
     };
 };
 export type MarkAllTodosMutationResponse = {

--- a/example/ts/__relay_artifacts__/RemoveCompletedTodosMutation.graphql.ts
+++ b/example/ts/__relay_artifacts__/RemoveCompletedTodosMutation.graphql.ts
@@ -3,7 +3,7 @@
 import { ConcreteRequest } from "relay-runtime";
 export type RemoveCompletedTodosMutationVariables = {
     readonly input: {
-        readonly clientMutationId: string | null;
+        readonly clientMutationId?: string | null;
     };
 };
 export type RemoveCompletedTodosMutationResponse = {

--- a/example/ts/__relay_artifacts__/RemoveTodoMutation.graphql.ts
+++ b/example/ts/__relay_artifacts__/RemoveTodoMutation.graphql.ts
@@ -3,8 +3,8 @@
 import { ConcreteRequest } from "relay-runtime";
 export type RemoveTodoMutationVariables = {
     readonly input: {
-        readonly id?: string;
-        readonly clientMutationId: string | null;
+        readonly id: string;
+        readonly clientMutationId?: string | null;
     };
 };
 export type RemoveTodoMutationResponse = {

--- a/example/ts/__relay_artifacts__/RenameTodoMutation.graphql.ts
+++ b/example/ts/__relay_artifacts__/RenameTodoMutation.graphql.ts
@@ -3,9 +3,9 @@
 import { ConcreteRequest } from "relay-runtime";
 export type RenameTodoMutationVariables = {
     readonly input: {
-        readonly id?: string;
-        readonly text?: string;
-        readonly clientMutationId: string | null;
+        readonly id: string;
+        readonly text: string;
+        readonly clientMutationId?: string | null;
     };
 };
 export type RenameTodoMutationResponse = {

--- a/src/TypeScriptTypeTransformers.ts
+++ b/src/TypeScriptTypeTransformers.ts
@@ -123,7 +123,7 @@ function transformNonNullableInputType(type: GraphQLInputType, state: State) {
         const property = ts.createPropertySignature(
           [ts.createToken(ts.SyntaxKind.ReadonlyKeyword)],
           ts.createIdentifier(field.name),
-          field.type instanceof GraphQLNonNull
+          !(field.type instanceof GraphQLNonNull)
             ? ts.createToken(ts.SyntaxKind.QuestionToken)
             : undefined,
           transformInputType(field.type, state),

--- a/test/__snapshots__/TypeScriptGenerator-test.ts.snap
+++ b/test/__snapshots__/TypeScriptGenerator-test.ts.snap
@@ -272,8 +272,8 @@ mutation CommentCreateMutation(
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 export type CommentCreateMutationVariables = {
     readonly input: {
-        readonly clientMutationId: string | null;
-        readonly feedbackId: string | null;
+        readonly clientMutationId?: string | null;
+        readonly feedbackId?: string | null;
     };
     readonly first?: number | null;
     readonly orderBy?: ReadonlyArray<string> | null;
@@ -305,8 +305,8 @@ mutation InputHasArray($input: UpdateAllSeenStateInput) {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 export type InputHasArrayVariables = {
     readonly input?: {
-        readonly clientMutationId: string | null;
-        readonly storyIds: ReadonlyArray<string | null> | null;
+        readonly clientMutationId?: string | null;
+        readonly storyIds?: ReadonlyArray<string | null> | null;
     } | null;
 };
 export type InputHasArrayResponse = {
@@ -378,8 +378,8 @@ export type ExampleFragment = {
 
 export type TestMutationVariables = {
     readonly input: {
-        readonly clientMutationId: string | null;
-        readonly feedbackId: string | null;
+        readonly clientMutationId?: string | null;
+        readonly feedbackId?: string | null;
     };
 };
 export type TestMutationResponse = {
@@ -393,8 +393,8 @@ export type TestMutationResponse = {
 
 export type TestSubscriptionVariables = {
     readonly input?: {
-        readonly clientMutationId: string | null;
-        readonly feedbackId: string | null;
+        readonly clientMutationId?: string | null;
+        readonly feedbackId?: string | null;
     } | null;
 };
 export type TestSubscriptionResponse = {


### PR DESCRIPTION
Within an input object, if the type of a field is nullable, it should
then be optional within typescript as well as allowing `null` as an
explicit value. Conversely, if the type of a field is non-nullable, it
should be both required as a property and not allowed to be `null`.