### PR TITLE
Adds continuous integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js: '8.4'
+cache: yarn


### PR DESCRIPTION
@alloy has already enabled Travis for this repo, so this PR only needs to specify the configuration to run tests against. Based on [the Travis Node docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/), we should be okay to use the default `yarn` and `yarn test` installation/test steps, respectively. 

~This PR is a work-in-progress because I'm not sure if the initial tests will pass. We'll see!~

Fixes #23.