### PR TITLE
[plugin] Make plugin work with Relay < 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ yourself. Alternatively, you can use prebuilt packages that [Artsy uses](https:/
 Add the package to your dev dependencies:
 
 ```
-yarn add relay-compiler-language-typescript --dev
+yarn add graphql-compiler --dev
+yarn add typescript relay-compiler-language-typescript --dev
 ```
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-compiler-language-typescript",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A language plugin for Relay that adds TypeScript support, including emitting type definitions.",
   "license": "MIT",
   "keywords": [

--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -16,13 +16,21 @@ import {
   GraphQLScalarType,
   GraphQLNamedType
 } from "graphql";
-import {
+
+// Get the types
+import * as GraphQLCompilerTypes from "graphql-compiler";
+// Load the actual code with a fallback to < Relay 1.6 which changed graphql-compiler to an actual package.
+let GraphQLCompiler: typeof GraphQLCompilerTypes
+try {
+  GraphQLCompiler = require("relay-compiler/lib/GraphQLCompilerPublic");
+}
+catch (err) {
+  GraphQLCompiler = require("graphql-compiler");
+}
+const {
   IRVisitor,
   SchemaUtils,
-  IRTransform,
-  Fragment,
-  Root
-} from "graphql-compiler";
+} = GraphQLCompiler;
 
 import { TypeGeneratorOptions } from "relay-compiler";
 
@@ -250,7 +258,7 @@ function mergeSelections(a: SelectionMap, b: SelectionMap): SelectionMap {
   return merged;
 }
 
-function isPlural(node: Fragment): boolean {
+function isPlural(node: GraphQLCompilerTypes.Fragment): boolean {
   return Boolean(node.metadata && node.metadata.plural);
 }
 
@@ -456,7 +464,7 @@ function generateInputObjectTypes(state: State) {
   });
 }
 
-function generateInputVariablesType(node: Root, state: State) {
+function generateInputVariablesType(node: GraphQLCompilerTypes.Root, state: State) {
   return exportType(
     `${node.name}Variables`,
     exactObjectTypeAnnotation(


### PR DESCRIPTION
At Artsy we can’t migrate to latest Relay that easily, as I need to bring other PRs up to date as well, so going to make it backwards compatible for now.