### PR TITLE
fix oboe for source location line

### DIFF
--- a/src/FindGraphQLTags.ts
+++ b/src/FindGraphQLTags.ts
@@ -171,7 +171,7 @@ function getSourceLocationOffset(quasi: ts.TaggedTemplateExpression) {
   const pos = getTemplateNode(quasi).pos;
   const loc = quasi.getSourceFile().getLineAndCharacterOfPosition(pos);
   return {
-    line: loc.line,
+    line: loc.line + 1,
     column: loc.character + 1
   };
 }

--- a/test/FindGraphQLTags-test.ts
+++ b/test/FindGraphQLTags-test.ts
@@ -23,9 +23,16 @@ describe('FindGraphQLTags', () => {
             name
           }
         `,
-      sourceLocationOffset: { line: 4, column: 16 },
+      sourceLocationOffset: { line: 5, column: 16 },
     }])
   })
 
+  it('extracts a tag in line 1', () => {
+    expect(find(`graphql\`fragment TestModule_artist on Artist {name}\``)).toEqual([{
+      keyName: null,
+      template: `fragment TestModule_artist on Artist {name}`,
+      sourceLocationOffset: { line: 1, column: 8 },
+    }])
+  })
   // TODO: Cover all cases where tags are extracted
 })


### PR DESCRIPTION
tl;dr there is an off by one error in the parser. the test that existed didn't factor in that the first blank line of a tagged template literal counts as line 1.


Reproduction:
1. write a tag in the first line of a file *and start the tagged template literal with a tick on line 1*
2. run relay-compiler using the typescript parser
3. get the following error:

```
Parse error: Error: line in locationOffset is 1-indexed and must be positive in ...
```

PS may be worth publishing this one as a hotfix since it breaks builds