### PR TITLE
Dont require relay runtime string

### DIFF
--- a/src/formatGeneratedModule.ts
+++ b/src/formatGeneratedModule.ts
@@ -7,7 +7,7 @@ export const formatGeneratedModule: FormatModule = ({
   concreteText,
   typeText,
   hash,
-  relayRuntimeModule,
+  relayRuntimeModule = "relay-runtime",
   sourceHash
 }) => {
   const documentTypeImport = documentType

--- a/test/formatGeneratedModule-test.ts
+++ b/test/formatGeneratedModule-test.ts
@@ -48,4 +48,16 @@ describe('formatGeneratedModule', () => {
       sourceHash: 'edcba',
     })).toMatchFile(join(__dirname, 'fixtures/generated-module/complete-example.ts'))
   })
+
+  it('works without passing relay runtime module explicitly', () => {
+    expect(formatGeneratedModule({
+      moduleName: 'complete-example',
+      documentType: 'ConcreteFragment',
+      docText: null,
+      concreteText: JSON.stringify({ the: { fragment: { data: 42 } }}),
+      typeText: 'export type CompleteExample = { readonly id: string }',
+      hash: 'abcde',
+      sourceHash: 'edcba',
+    })).toMatchFile(join(__dirname, 'fixtures/generated-module/complete-example.ts'))
+  })
 })


### PR DESCRIPTION
Hello 👋 !

[`relay-compiler` doesn't have a relay runtime module as a argument in version 2](https://github.com/facebook/relay/commit/dce32eaa485238569c3060366b693c95b07d631f).

This causes me to get:

```ts
import { ConcreteFragment } from "undefined";
```

when generating the graphql files.

This patch defaults the `relayRuntimeModule` string to `relay-runtime` which fixes the error for me and makes sure to respect the value if one is passed in.

Ref: #73 