### PR TITLE
Add support for noFutureProofEnums

### DIFF
--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -290,7 +290,8 @@ function createVisitor(options: TypeGeneratorOptions) {
     usedEnums: {},
     usedFragments: new Set(),
     useHaste: options.useHaste,
-    useSingleArtifactDirectory: options.useSingleArtifactDirectory
+    useSingleArtifactDirectory: options.useSingleArtifactDirectory,
+    noFutureProofEnums: options.noFutureProofEnums
   };
 
   return {
@@ -564,7 +565,11 @@ function anyTypeAlias(typeName: string): ts.Statement {
   );
 }
 
-function getEnumDefinitions({ enumsHasteModule, usedEnums }: State) {
+function getEnumDefinitions({
+  enumsHasteModule,
+  usedEnums,
+  noFutureProofEnums
+}: State) {
   const enumNames = Object.keys(usedEnums).sort();
   if (enumNames.length === 0) {
     return [];
@@ -575,7 +580,9 @@ function getEnumDefinitions({ enumsHasteModule, usedEnums }: State) {
   return enumNames.map(name => {
     const values = usedEnums[name].getValues().map(({ value }) => value);
     values.sort();
-    values.push("%future added value");
+    if (!noFutureProofEnums) {
+      values.push("%future added value");
+    }
     return exportType(
       name,
       ts.createUnionTypeNode(

--- a/test/TypeScriptGenerator-test.ts
+++ b/test/TypeScriptGenerator-test.ts
@@ -6,51 +6,64 @@ import {GraphQLCompilerContext, IRTransforms, transformASTSchema} from 'relay-co
 
 import * as TypeScriptGenerator from '../src/TypeScriptGenerator'
 
+function generate(text, options) {
+  const schema = transformASTSchema(RelayTestSchema, [
+    IRTransforms.schemaExtensions[1], // RelayRelayDirectiveTransform.SCHEMA_EXTENSION,
+  ]);
+  const {definitions} = parseGraphQLText(schema, text);
+  return new GraphQLCompilerContext(RelayTestSchema, schema)
+    .addAll(definitions)
+    .applyTransforms(TypeScriptGenerator.transforms)
+    .documents()
+    .map(doc => TypeScriptGenerator.generate(doc, options))
+    .join('\n\n');
+}
+
 describe('TypeScriptGenerator with a single artifact directory', () => {
-  generateTestsFromFixtures(`${__dirname}/fixtures/type-generator`, text => {
-    const schema = transformASTSchema(RelayTestSchema, [
-      IRTransforms.schemaExtensions[1], // RelayRelayDirectiveTransform.SCHEMA_EXTENSION,
-    ]);
-    const {definitions} = parseGraphQLText(schema, text);
-    return new GraphQLCompilerContext(RelayTestSchema, schema)
-      .addAll(definitions)
-      .applyTransforms(TypeScriptGenerator.transforms)
-      .documents()
-      .map(doc =>
-        TypeScriptGenerator.generate(doc, {
-          customScalars: {},
-          enumsHasteModule: null,
-          existingFragmentNames: new Set(['PhotoFragment']),
-          optionalInputFields: [],
-          relayRuntimeModule: 'relay-runtime',
-          useHaste: false,
-          useSingleArtifactDirectory: true,
-        }),
-      )
-      .join('\n\n');
-  });
+  generateTestsFromFixtures(`${__dirname}/fixtures/type-generator`, text =>
+    generate(text, {
+      customScalars: {},
+      enumsHasteModule: null,
+      existingFragmentNames: new Set(['PhotoFragment']),
+      optionalInputFields: [],
+      relayRuntimeModule: 'relay-runtime',
+      useHaste: false,
+      useSingleArtifactDirectory: true,
+    }),
+  );
 });
 
 describe('TypeScriptGenerator without a single artifact directory', () => {
-  generateTestsFromFixtures(`${__dirname}/fixtures/type-generator`, text => {
-    const schema = transformASTSchema(RelayTestSchema, [
-      IRTransforms.schemaExtensions[1], // RelayRelayDirectiveTransform.SCHEMA_EXTENSION,
-    ]);
-    const {definitions} = parseGraphQLText(schema, text);
-    return new GraphQLCompilerContext(RelayTestSchema, schema)
-      .addAll(definitions)
-      .applyTransforms(TypeScriptGenerator.transforms)
-      .documents()
-      .map(doc =>
-        TypeScriptGenerator.generate(doc, {
-          customScalars: {},
-          enumsHasteModule: null,
-          existingFragmentNames: new Set(['PhotoFragment']),
-          optionalInputFields: [],
-          relayRuntimeModule: 'relay-runtime',
-          useHaste: true,
-        }),
-      )
-      .join('\n\n');
+  generateTestsFromFixtures(`${__dirname}/fixtures/type-generator`, text =>
+    generate(text, {
+      customScalars: {},
+      enumsHasteModule: null,
+      existingFragmentNames: new Set(['PhotoFragment']),
+      optionalInputFields: [],
+      relayRuntimeModule: 'relay-runtime',
+      useHaste: false,
+    }),
+  );
+});
+
+describe('Does not add `%future added values` when the noFutureProofEnums option is set', () => {
+  const text = `
+    fragment ScalarField on User {
+      traits
+    }
+  `;
+  const types = generate(text, {
+    customScalars: {},
+    enumsHasteModule: null,
+    existingFragmentNames: new Set(['PhotoFragment']),
+    optionalInputFields: [],
+    relayRuntimeModule: 'relay-runtime',
+    useHaste: false,
+    noFutureProofEnums: true,
   });
+
+  // Without the option, PersonalityTraits would be `"CHEERFUL" | ... | "%future added value");`
+  expect(types).toContain(
+    'export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY";',
+  );
 });

--- a/types/relay-compiler/language/RelayLanguagePluginInterface.d.ts
+++ b/types/relay-compiler/language/RelayLanguagePluginInterface.d.ts
@@ -43,6 +43,7 @@ export interface TypeGeneratorOptions {
   readonly optionalInputFields: ReadonlyArray<string>;
   readonly relayRuntimeModule: string;
   readonly useSingleArtifactDirectory: boolean;
+  readonly noFutureProofEnums: boolean;
 }
 
 export interface TypeGenerator {


### PR DESCRIPTION
Implementation `noFutureProofEnums` as issue #80, #81.
Code ported from upstream as resolved in https://github.com/facebook/relay/issues/2351

This change allows to pass in CLI `--noFutureProofEnums` to avoid inclusion in enums of `"%future added value"`.

A test was added for this case, plus a small refactoring of test to keep it DRY and similar to upstream implementation.

@alloy @sibelius @steida
