### PR TITLE
Ignore npmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ typings/
 .vscode
 /lib
 /bin
+
+.npmrc


### PR DESCRIPTION
There's an issue w/ the deployment process caused by the .npmrc being added by ci but not being ignored by git. This should resolve that issue.