### PR TITLE
Add support for devOnlyAssignments

### DIFF
--- a/test/fixtures/generated-module/complete-example.ts
+++ b/test/fixtures/generated-module/complete-example.ts
@@ -5,5 +5,6 @@ export type CompleteExample = { readonly id: string }
 
 
 const node: ConcreteFragment = ({ "the": { "fragment": { "data": 42 } } } as any);
+
 (node as any).hash = 'edcba';
 export default node;

--- a/test/fixtures/generated-module/dev-only-assignments.ts
+++ b/test/fixtures/generated-module/dev-only-assignments.ts
@@ -6,5 +6,8 @@ export type CompleteExample = { readonly id: string }
 
 const node: ConcreteFragment = {"the":{"fragment":{"data":42}}};
 
+if (process.env.NODE_ENV !== 'production') {
+  (node as any).params.text = "query CompleteExampleQuery { id }";
+}
 (node as any).hash = 'edcba';
 export default node;

--- a/test/formatGeneratedModule-test.ts
+++ b/test/formatGeneratedModule-test.ts
@@ -75,4 +75,18 @@ describe('formatGeneratedModule', () => {
       sourceHash: 'edcba',
     })).toMatchFile(join(__dirname, 'fixtures/generated-module/complete-example-no-cast.ts'))
   })
+
+  it('works with devOnlyAssignments', () => {
+    const formatGeneratedModule = formatterFactory();
+    expect(formatGeneratedModule({
+      moduleName: 'complete-example',
+      documentType: 'ConcreteFragment',
+      docText: null,
+      concreteText: JSON.stringify({ the: { fragment: { data: 42 } }}),
+      typeText: 'export type CompleteExample = { readonly id: string }',
+      hash: 'abcde',
+      sourceHash: 'edcba',
+      devOnlyAssignments: '(node/*: any*/).params.text = "query CompleteExampleQuery { id }";',
+    })).toMatchFile(join(__dirname, 'fixtures/generated-module/dev-only-assignments.ts'))
+  })
 })


### PR DESCRIPTION
Closes #93 

Add support for https://github.com/facebook/relay/blob/f8585ab4f90f2e707d5555c9f7b423de3ea553bd/packages/relay-compiler/language/RelayLanguagePluginInterface.js#L176.

My main questions is whether this is a breaking change or not and if it should be enabled by default. Also should we make the dev check `process.env.NODE_ENV !== 'production'` configurable?