### PR TITLE
Ensure dependencies are present so the release can succeed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 before_deploy:
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 deploy:
+  skip_cleanup: true
   provider: script
   script: bash scripts/deploy.sh
   on:


### PR DESCRIPTION
Fixes an issue where travis was removing `node_modules` before deployment. Specifying `skip_cleanup` will ensure dependencies are still around for auto to do its thing. 

Thanks @alloy for the extra eyeballs!