### PR TITLE
Manually checkout master to fix git deploy fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ script:
 
 before_deploy:
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+  - git checkout master && git pull origin
+  - yarn build
 deploy:
   skip_cleanup: true
   provider: script


### PR DESCRIPTION
@alloy this probably isn't ideal, but there have been some git failures when trying to deploy with auto about it begin detached from HEAD. I think it's because Travis checks out a hash and auto is trying to commit changelog entries and stuff. 

Hopefully this fixes it.