### PR TITLE
Re-port `selectionsToBabel` -> `selectionsToAST` to fixup union type decls

### DIFF
--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -1,3 +1,4 @@
+import { GraphQLNonNull, GraphQLString } from "graphql";
 import {
   Fragment,
   IRTransforms,
@@ -7,11 +8,15 @@ import {
   TypeGenerator,
   TypeGeneratorOptions
 } from "relay-compiler";
-import * as RelayCompilerPublic from "relay-compiler";
-
-import { GraphQLNonNull, GraphQLString } from "graphql";
+import {
+  Condition,
+  FragmentSpread,
+  InlineFragment,
+  LinkedField,
+  ModuleImport,
+  ScalarField
+} from "types/relay-compiler/core/GraphQLIR";
 import * as ts from "typescript";
-
 import {
   State,
   transformInputType,
@@ -22,6 +27,7 @@ const { isAbstractType } = SchemaUtils;
 
 const REF_TYPE = " $refType";
 const FRAGMENT_REFS = " $fragmentRefs";
+const DATA = " $data";
 
 export const generate: TypeGenerator["generate"] = (node, options) => {
   const ast: ts.Statement[] = IRVisitor.visit(node, createVisitor(options));
@@ -94,7 +100,7 @@ function selectionsToAST(
   selections: Selection[][],
   state: State,
   unmasked: boolean,
-  refTypeName?: string
+  fragmentTypeName?: string
 ): ts.TypeNode {
   const baseFields = new Map<string, Selection>();
   const byConcreteType: { [type: string]: Selection[] } = {};
@@ -115,6 +121,7 @@ function selectionsToAST(
   });
 
   const types: ts.PropertySignature[][] = [];
+
   if (
     Object.keys(byConcreteType).length > 0 &&
     onlySelectsTypename(Array.from(baseFields.values())) &&
@@ -138,6 +145,9 @@ function selectionsToAST(
       );
     }
 
+    // It might be some other type then the listed concrete types. Ideally, we
+    // would set the type to diff(string, set of listed concrete types), but
+    // this doesn't exist in Flow at the time.
     types.push(
       Array.from(typenameAliases).map(typenameAlias => {
         const otherProp = readOnlyObjectTypeProperty(
@@ -185,12 +195,12 @@ function selectionsToAST(
   }
 
   const typeElements = types.map(props => {
-    if (refTypeName) {
+    if (fragmentTypeName) {
       props.push(
         readOnlyObjectTypeProperty(
           REF_TYPE,
           ts.createTypeReferenceNode(
-            ts.createIdentifier(refTypeName),
+            ts.createIdentifier(fragmentTypeName),
             undefined
           )
         )
@@ -304,21 +314,27 @@ function createVisitor(options: TypeGeneratorOptions) {
     usedFragments: new Set(),
     useHaste: options.useHaste,
     useSingleArtifactDirectory: options.useSingleArtifactDirectory,
-    noFutureProofEnums: options.noFutureProofEnums
+    noFutureProofEnums: options.noFutureProofEnums,
+    matchFields: new Map()
   };
 
   return {
     leave: {
-      Root(node: any) {
+      Root(node: Root) {
         const inputVariablesType = generateInputVariablesType(node, state);
         const inputObjectTypes = generateInputObjectTypes(state);
         const responseType = exportType(
           `${node.name}Response`,
-          selectionsToAST(node.selections, state, false)
+          // From flow code: $FlowFixMe: selections have already been transformed
+          selectionsToAST(
+            (node.selections as any) as Selection[][],
+            state,
+            false
+          )
         );
         const operationType = exportType(
           node.name,
-          exactObjectTypeAnnotation([
+          ts.createTypeLiteralNode([
             readOnlyObjectTypeProperty(
               "response",
               ts.createTypeReferenceNode(responseType.name, undefined)
@@ -339,8 +355,11 @@ function createVisitor(options: TypeGeneratorOptions) {
         ];
       },
 
-      Fragment(node: any) {
-        const flattenedSelections: Selection[] = flattenArray(node.selections);
+      Fragment(node: Fragment) {
+        // From flow code: $FlowFixMe: selections have already been transformed
+        const flattenedSelections: Selection[] = flattenArray(
+          (node.selections as any) as Selection[][]
+        );
         const numConcreteSelections = flattenedSelections.filter(
           s => s.concreteType
         ).length;
@@ -360,100 +379,87 @@ function createVisitor(options: TypeGeneratorOptions) {
           return [selection];
         });
         state.generatedFragments.add(node.name);
-        const refTypeName = getRefTypeName(node.name);
-        const refTypeNodes: ts.Node[] = [];
-        if (options.useSingleArtifactDirectory) {
-          const _refTypeName = `_${refTypeName}`;
-          const _refType = ts.createVariableStatement(
-            [ts.createToken(ts.SyntaxKind.DeclareKeyword)],
-            ts.createVariableDeclarationList(
-              [
-                ts.createVariableDeclaration(
-                  _refTypeName,
-                  ts.createTypeOperatorNode(
-                    ts.SyntaxKind.UniqueKeyword,
-                    ts.createKeywordTypeNode(ts.SyntaxKind.SymbolKeyword)
-                  )
-                )
-              ],
-              ts.NodeFlags.Const
-            )
-          );
-          const refType = exportType(
-            refTypeName,
-            ts.createTypeQueryNode(ts.createIdentifier(_refTypeName))
-          );
-          refTypeNodes.push(_refType);
-          refTypeNodes.push(refType);
-        } else {
-          const refType = exportType(
-            refTypeName,
-            ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)
-          );
-          refTypeNodes.push(refType);
-        }
+        const fragmentTypes = getFragmentTypes(
+          node.name,
+          options.useSingleArtifactDirectory
+        );
+
+        const dataType = ts.createTypeReferenceNode(node.name, undefined);
+
         const unmasked = node.metadata != null && node.metadata.mask === false;
         const baseType = selectionsToAST(
           selections,
           state,
           unmasked,
-          refTypeName
+          unmasked ? undefined : getOldFragmentTypeName(node.name)
         );
         const type = isPlural(node)
           ? ts.createTypeReferenceNode(ts.createIdentifier("ReadonlyArray"), [
               baseType
             ])
           : baseType;
+
         return [
           ...getFragmentImports(state),
           ...getEnumDefinitions(state),
-          ...refTypeNodes,
+          ...fragmentTypes,
           exportType(node.name, type)
         ];
       },
-
-      InlineFragment(node: any) {
+      InlineFragment(node: InlineFragment) {
         const typeCondition = node.typeCondition;
-        return flattenArray(node.selections).map(typeSelection => {
-          return isAbstractType(typeCondition)
-            ? {
-                ...typeSelection,
-                conditional: true
-              }
-            : {
-                ...typeSelection,
-                concreteType: typeCondition.toString()
-              };
-        });
+        // From flow code: $FlowFixMe: selections have already been transformed
+        return flattenArray((node.selections as any) as Selection[][]).map(
+          typeSelection => {
+            return isAbstractType(typeCondition)
+              ? {
+                  ...typeSelection,
+                  conditional: true
+                }
+              : {
+                  ...typeSelection,
+                  concreteType: typeCondition.toString()
+                };
+          }
+        );
       },
-      Condition(node: any) {
-        return flattenArray(node.selections).map(selection => {
-          return {
-            ...selection,
-            conditional: true
-          };
-        });
+      Condition(node: Condition) {
+        return flattenArray((node.selections as any) as Selection[][]).map(
+          selection => {
+            return {
+              ...selection,
+              conditional: true
+            };
+          }
+        );
       },
-      ScalarField(node: any) {
+      ScalarField(node: ScalarField) {
         return [
           {
-            key: node.alias || node.name,
+            key: node.alias == null ? node.name : node.alias,
             schemaName: node.name,
             value: transformScalarType(node.type, state)
           }
         ];
       },
-      LinkedField(node: any) {
+      LinkedField(node: LinkedField) {
         return [
           {
-            key: node.alias || node.name,
+            key: node.alias == null ? node.name : node.alias,
             schemaName: node.name,
             nodeType: node.type,
-            nodeSelections: selectionsToMap(flattenArray(node.selections))
+            nodeSelections: selectionsToMap(
+              flattenArray((node.selections as any) as Selection[][]),
+              /*
+               * append concreteType to key so overlapping fields with different
+               * concreteTypes don't get overwritten by each other
+               */
+              true
+            )
           }
         ];
       },
-      ModuleImport(node: any) {
+      ModuleImport(node: ModuleImport) {
         return [
           {
             key: "__fragmentPropName",
@@ -471,7 +477,7 @@ function createVisitor(options: TypeGeneratorOptions) {
           }
         ];
       },
-      FragmentSpread(node: any) {
+      FragmentSpread(node: FragmentSpread) {
         state.usedFragments.add(node.name);
         return [
           {
@@ -484,12 +490,19 @@ function createVisitor(options: TypeGeneratorOptions) {
   };
 }
 
-function selectionsToMap(selections: Selection[]): SelectionMap {
+function selectionsToMap(
+  selections: Selection[],
+  appendType?: boolean
+): SelectionMap {
   const map = new Map();
   selections.forEach(selection => {
-    const previousSel = map.get(selection.key);
+    const key =
+      appendType && selection.concreteType
+        ? `${selection.key}::${selection.concreteType}`
+        : selection.key;
+    const previousSel = map.get(key);
     map.set(
-      selection.key,
+      key,
       previousSel ? mergeSelection(previousSel, selection) : selection
     );
   });
@@ -545,7 +558,7 @@ function groupRefs(props: Selection[]): Selection[] {
     const value = ts.createIntersectionTypeNode(
       refs.map(ref =>
         ts.createTypeReferenceNode(
-          ts.createIdentifier(getRefTypeName(ref)),
+          ts.createIdentifier(getOldFragmentTypeName(ref)),
           undefined
         )
       )
@@ -574,29 +587,21 @@ function getFragmentImports(state: State) {
   if (state.usedFragments.size > 0) {
     const usedFragments = Array.from(state.usedFragments).sort();
     for (const usedFragment of usedFragments) {
-      const refTypeName = getRefTypeName(usedFragment);
+      const fragmentTypeName = getOldFragmentTypeName(usedFragment);
       if (
         !state.generatedFragments.has(usedFragment) &&
         state.useSingleArtifactDirectory &&
         state.existingFragmentNames.has(usedFragment)
       ) {
-        imports.push(importTypes([refTypeName], `./${usedFragment}.graphql`));
+        imports.push(
+          importTypes([fragmentTypeName], `./${usedFragment}.graphql`)
+        );
       } else {
-        imports.push(createAnyTypeAlias(refTypeName));
+        imports.push(createAnyTypeAlias(fragmentTypeName));
       }
     }
   }
   return imports;
-}
-
-function anyTypeAlias(typeName: string): ts.Statement {
-  return ts.createTypeAliasDeclaration(
-    undefined,
-    undefined,
-    ts.createIdentifier(typeName),
-    undefined,
-    ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)
-  );
 }
 
 function getEnumDefinitions({
@@ -608,8 +613,13 @@ function getEnumDefinitions({
   if (enumNames.length === 0) {
     return [];
   }
-  if (enumsHasteModule) {
+  if (typeof enumsHasteModule === "string") {
     return [importTypes(enumNames, enumsHasteModule)];
+  }
+  if (typeof enumsHasteModule === "function") {
+    return enumNames.map(enumName =>
+      importTypes([enumName], enumsHasteModule(enumName))
+    );
   }
   return enumNames.map(name => {
     const values = usedEnums[name].getValues().map(({ value }) => value);
@@ -630,7 +640,45 @@ function stringLiteralTypeAnnotation(name: string): ts.TypeNode {
   return ts.createLiteralTypeNode(ts.createLiteral(name));
 }
 
-function getRefTypeName(name: string): string {
+function getFragmentTypes(name: string, useSingleArtifactDirectory: boolean) {
+  const oldFragmentTypeName = getOldFragmentTypeName(name);
+
+  if (!useSingleArtifactDirectory) {
+    return [
+      exportType(
+        oldFragmentTypeName,
+        ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)
+      )
+    ];
+  }
+
+  const _refTypeName = `_${oldFragmentTypeName}`;
+  const _refType = ts.createVariableStatement(
+    [ts.createToken(ts.SyntaxKind.DeclareKeyword)],
+    ts.createVariableDeclarationList(
+      [
+        ts.createVariableDeclaration(
+          _refTypeName,
+          ts.createTypeOperatorNode(
+            ts.SyntaxKind.UniqueKeyword,
+            ts.createKeywordTypeNode(ts.SyntaxKind.SymbolKeyword)
+          )
+        )
+      ],
+      ts.NodeFlags.Const
+    )
+  );
+
+  return [
+    _refType,
+    exportType(
+      oldFragmentTypeName,
+      ts.createTypeQueryNode(ts.createIdentifier(_refTypeName))
+    )
+  ];
+}
+
+function getOldFragmentTypeName(name: string) {
   return `${name}$ref`;
 }
 
@@ -639,6 +687,7 @@ function getRefTypeName(name: string): string {
 export const transforms: TypeGenerator["transforms"] = [
   IRTransforms.commonTransforms[1], // RelayRelayDirectiveTransform.transform,
   IRTransforms.commonTransforms[2], // RelayMaskTransform.transform,
+  IRTransforms.commonTransforms[0], // RelayConnectionTransform.transform,
   IRTransforms.commonTransforms[3], // RelayMatchTransform.transform,
   IRTransforms.printTransforms[3], // FlattenTransform.transformWithOptions({}),
   IRTransforms.commonTransforms[4] // RelayRefetchableFragmentTransform.transform,

--- a/src/TypeScriptTypeTransformers.ts
+++ b/src/TypeScriptTypeTransformers.ts
@@ -24,6 +24,7 @@ export type State = {
     [name: string]: ts.TypeNode | "pending";
   };
   generatedFragments: Set<string>;
+  matchFields: Map<string, ts.TypeNode>;
 } & TypeGeneratorOptions;
 
 function getInputObjectTypeIdentifier(type: GraphQLInputObjectType): string {

--- a/test/TypeScriptGenerator-test.ts
+++ b/test/TypeScriptGenerator-test.ts
@@ -1,11 +1,13 @@
+import * as parseGraphQLText from "relay-test-utils/lib/parseGraphQLText";
+import { generateTestsFromFixtures } from "relay-test-utils/lib/RelayModernTestUtils";
+import * as RelayTestSchema from "relay-test-utils/lib/RelayTestSchema";
+
 import {
   GraphQLCompilerContext,
   IRTransforms,
   transformASTSchema
 } from "relay-compiler";
-import { generateTestsFromFixtures } from "relay-test-utils/lib/RelayModernTestUtils";
-import * as RelayTestSchema from "relay-test-utils/lib/RelayTestSchema";
-import * as parseGraphQLText from "relay-test-utils/lib/parseGraphQLText";
+
 import * as TypeScriptGenerator from "../src/TypeScriptGenerator";
 
 function generate(text, options) {

--- a/test/__snapshots__/TypeScriptGenerator-test.ts.snap
+++ b/test/__snapshots__/TypeScriptGenerator-test.ts.snap
@@ -79,13 +79,7 @@ export type FragmentSpread = {
     } | null;
     readonly " $fragmentRefs": OtherFragment$ref & UserFrag1$ref & UserFrag2$ref;
     readonly " $refType": FragmentSpread$ref;
-} & ({
-    readonly " $fragmentRefs": UserFrag1$ref & UserFrag2$ref;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 type PageFragment$ref = any;
@@ -93,11 +87,6 @@ declare const _ConcreateTypes$ref: unique symbol;
 export type ConcreateTypes$ref = typeof _ConcreateTypes$ref;
 export type ConcreateTypes = {
     readonly actor: ({
-        readonly __typename: string;
-        readonly id?: string;
-        readonly name?: string | null;
-        readonly " $fragmentRefs": PageFragment$ref;
-    } & ({
         readonly __typename: "Page";
         readonly id: string;
         readonly " $fragmentRefs": PageFragment$ref;
@@ -105,10 +94,10 @@ export type ConcreateTypes = {
         readonly __typename: "User";
         readonly name: string | null;
     } | {
-        /*This will never be '% other', but we need some
+        /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
-    })) | null;
+    }) | null;
     readonly " $refType": ConcreateTypes$ref;
 };
 
@@ -187,15 +176,7 @@ export type InlineFragment = {
         readonly text: string | null;
     } | null;
     readonly " $refType": InlineFragment$ref;
-} & ({
-    readonly message: {
-        readonly text: string | null;
-    } | null;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 declare const _InlineFragmentWithOverlappingFields$ref: unique symbol;
@@ -210,24 +191,7 @@ export type InlineFragmentWithOverlappingFields = {
     } | null;
     readonly name?: string | null;
     readonly " $refType": InlineFragmentWithOverlappingFields$ref;
-} & ({
-    readonly hometown: {
-        readonly id: string;
-        readonly name: string | null;
-    } | null;
-} | {
-    readonly name: string | null;
-    readonly hometown: {
-        readonly id: string;
-        readonly message: {
-            readonly text: string | null;
-        } | null;
-    } | null;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 declare const _InlineFragmentConditionalID$ref: unique symbol;
@@ -243,7 +207,7 @@ type SomeFragment$ref = any;
 declare const _InlineFragmentKitchenSink$ref: unique symbol;
 export type InlineFragmentKitchenSink$ref = typeof _InlineFragmentKitchenSink$ref;
 export type InlineFragmentKitchenSink = {
-    readonly actor: ({
+    readonly actor: {
         readonly id: string;
         readonly profilePicture: {
             readonly uri: string | null;
@@ -252,14 +216,7 @@ export type InlineFragmentKitchenSink = {
         } | null;
         readonly name?: string | null;
         readonly " $fragmentRefs": SomeFragment$ref;
-    } & ({
-        readonly name: string | null;
-        readonly " $fragmentRefs": SomeFragment$ref;
-    } | {
-        /*This will never be '% other', but we need some
-        value in case none of the concrete values match.*/
-        readonly __typename: "%other";
-    })) | null;
+    } | null;
     readonly " $refType": InlineFragmentKitchenSink$ref;
 };
 
@@ -320,16 +277,13 @@ export type LinkedField = {
 export type UnionTypeTestVariables = {};
 export type UnionTypeTestResponse = {
     readonly neverNode: ({
-        readonly __typename: string;
-        readonly id?: string;
-    } & ({
         readonly __typename: "FakeNode";
         readonly id: string;
     } | {
-        /*This will never be '% other', but we need some
+        /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
-    })) | null;
+    }) | null;
 };
 export type UnionTypeTest = {
     readonly response: UnionTypeTestResponse;
@@ -370,21 +324,11 @@ declare const _NameRendererFragment$ref: unique symbol;
 export type NameRendererFragment$ref = typeof _NameRendererFragment$ref;
 export type NameRendererFragment = {
     readonly id: string;
-    readonly nameRenderer: ({
+    readonly nameRenderer: {
         readonly __fragmentPropName?: string | null;
         readonly __module_component?: string | null;
         readonly " $fragmentRefs": PlainUserNameRenderer_name$ref & MarkdownUserNameRenderer_name$ref;
-    } & ({
-        readonly __fragmentPropName?: string | null;
-        readonly __module_component: string | null;
-        readonly " $fragmentRefs": PlainUserNameRenderer_name$ref;
-    } | {
-        readonly " $fragmentRefs": MarkdownUserNameRenderer_name$ref;
-    } | {
-        /*This will never be '% other', but we need some
-        value in case none of the concrete values match.*/
-        readonly __typename: "%other";
-    })) | null;
+    } | null;
     readonly " $refType": NameRendererFragment$ref;
 };
 
@@ -444,21 +388,11 @@ type PlainUserNameRenderer_name$ref = any;
 export type NameRendererQueryVariables = {};
 export type NameRendererQueryResponse = {
     readonly me: {
-        readonly nameRenderer: ({
+        readonly nameRenderer: {
             readonly __fragmentPropName?: string | null;
             readonly __module_component?: string | null;
             readonly " $fragmentRefs": PlainUserNameRenderer_name$ref & MarkdownUserNameRenderer_name$ref;
-        } & ({
-            readonly __fragmentPropName?: string | null;
-            readonly __module_component: string | null;
-            readonly " $fragmentRefs": PlainUserNameRenderer_name$ref;
-        } | {
-            readonly " $fragmentRefs": MarkdownUserNameRenderer_name$ref;
-        } | {
-            /*This will never be '% other', but we need some
-            value in case none of the concrete values match.*/
-            readonly __typename: "%other";
-        })) | null;
+        } | null;
     } | null;
 };
 export type NameRendererQuery = {
@@ -772,13 +706,6 @@ declare const _TypenameInsideWithOverlappingFields$ref: unique symbol;
 export type TypenameInsideWithOverlappingFields$ref = typeof _TypenameInsideWithOverlappingFields$ref;
 export type TypenameInsideWithOverlappingFields = {
     readonly actor: ({
-        readonly __typename: string;
-        readonly id?: string;
-        readonly name?: string | null;
-        readonly profile_picture?: {
-            readonly uri: string | null;
-        } | null;
-    } & ({
         readonly __typename: "Page";
         readonly id: string;
         readonly name: string | null;
@@ -788,10 +715,10 @@ export type TypenameInsideWithOverlappingFields = {
             readonly uri: string | null;
         } | null;
     } | {
-        /*This will never be '% other', but we need some
+        /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
-    })) | null;
+    }) | null;
     readonly " $refType": TypenameInsideWithOverlappingFields$ref;
 };
 
@@ -825,13 +752,6 @@ declare const _TypenameInsideWithOverlappingFieldsFull$ref: unique symbol;
 export type TypenameInsideWithOverlappingFieldsFull$ref = typeof _TypenameInsideWithOverlappingFieldsFull$ref;
 export type TypenameInsideWithOverlappingFieldsFull = {
     readonly actor: ({
-        readonly __typename: string;
-        readonly id?: string;
-        readonly name?: string | null;
-        readonly profile_picture?: {
-            readonly uri: string | null;
-        } | null;
-    } & ({
         readonly __typename: "Page";
         readonly id: string;
         readonly name: string | null;
@@ -841,10 +761,10 @@ export type TypenameInsideWithOverlappingFieldsFull = {
             readonly uri: string | null;
         } | null;
     } | {
-        /*This will never be '% other', but we need some
+        /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
-    })) | null;
+    }) | null;
     readonly " $refType": TypenameInsideWithOverlappingFieldsFull$ref;
 };
 
@@ -939,40 +859,36 @@ declare const _TypenameInside$ref: unique symbol;
 export type TypenameInside$ref = typeof _TypenameInside$ref;
 export type TypenameInside = {
     readonly __typename: "User";
-    readonly firstName?: string | null;
-    readonly username?: string | null;
-    readonly " $refType": TypenameInside$ref;
-} & ({
-    readonly __typename: "User";
     readonly firstName: string | null;
+    readonly " $refType": TypenameInside$ref;
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
+    readonly " $refType": TypenameInside$ref;
 } | {
-    /*This will never be '% other', but we need some
+    /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-});
+    readonly " $refType": TypenameInside$ref;
+};
 
 
 declare const _TypenameOutside$ref: unique symbol;
 export type TypenameOutside$ref = typeof _TypenameOutside$ref;
 export type TypenameOutside = {
-    readonly __typename: string;
-    readonly firstName?: string | null;
-    readonly username?: string | null;
-    readonly " $refType": TypenameOutside$ref;
-} & ({
     readonly __typename: "User";
     readonly firstName: string | null;
+    readonly " $refType": TypenameOutside$ref;
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
+    readonly " $refType": TypenameOutside$ref;
 } | {
-    /*This will never be '% other', but we need some
+    /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-});
+    readonly " $refType": TypenameOutside$ref;
+};
 
 
 declare const _TypenameOutsideWithAbstractType$ref: unique symbol;
@@ -987,18 +903,7 @@ export type TypenameOutsideWithAbstractType = {
     } | null;
     readonly firstName?: string | null;
     readonly " $refType": TypenameOutsideWithAbstractType$ref;
-} & ({
-    readonly __typename: "User";
-    readonly firstName: string | null;
-    readonly address: {
-        readonly street: string | null;
-        readonly city: string | null;
-    } | null;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 declare const _TypenameWithoutSpreads$ref: unique symbol;
@@ -1007,13 +912,7 @@ export type TypenameWithoutSpreads = {
     readonly firstName: string | null;
     readonly __typename: "User";
     readonly " $refType": TypenameWithoutSpreads$ref;
-} & ({
-    readonly __typename: "User";
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 declare const _TypenameWithoutSpreadsAbstractType$ref: unique symbol;
@@ -1033,60 +932,48 @@ export type TypenameWithCommonSelections = {
     readonly firstName?: string | null;
     readonly username?: string | null;
     readonly " $refType": TypenameWithCommonSelections$ref;
-} & ({
-    readonly __typename: "User";
-    readonly firstName: string | null;
-} | {
-    readonly __typename: "Page";
-    readonly username: string | null;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 declare const _TypenameAlias$ref: unique symbol;
 export type TypenameAlias$ref = typeof _TypenameAlias$ref;
 export type TypenameAlias = {
-    readonly _typeAlias: string;
-    readonly firstName?: string | null;
-    readonly username?: string | null;
-    readonly " $refType": TypenameAlias$ref;
-} & ({
     readonly _typeAlias: "User";
     readonly firstName: string | null;
+    readonly " $refType": TypenameAlias$ref;
 } | {
     readonly _typeAlias: "Page";
     readonly username: string | null;
+    readonly " $refType": TypenameAlias$ref;
 } | {
-    /*This will never be '% other', but we need some
+    /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+    readonly _typeAlias: "%other";
+    readonly " $refType": TypenameAlias$ref;
+};
 
 
 declare const _TypenameAliases$ref: unique symbol;
 export type TypenameAliases$ref = typeof _TypenameAliases$ref;
 export type TypenameAliases = {
-    readonly _typeAlias1: string;
-    readonly _typeAlias2: string;
-    readonly firstName?: string | null;
-    readonly username?: string | null;
-    readonly " $refType": TypenameAliases$ref;
-} & ({
     readonly _typeAlias1: "User";
     readonly _typeAlias2: "User";
     readonly firstName: string | null;
+    readonly " $refType": TypenameAliases$ref;
 } | {
     readonly _typeAlias1: "Page";
     readonly _typeAlias2: "Page";
     readonly username: string | null;
+    readonly " $refType": TypenameAliases$ref;
 } | {
-    /*This will never be '% other', but we need some
+    /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+    readonly _typeAlias1: "%other";
+    /*This will never be '%other', but we need some
+    value in case none of the concrete values match.*/
+    readonly _typeAlias2: "%other";
+    readonly " $refType": TypenameAliases$ref;
+};
 
 `;
 
@@ -1254,24 +1141,13 @@ export type FragmentSpread = {
     } | null;
     readonly " $fragmentRefs": OtherFragment$ref & UserFrag1$ref & UserFrag2$ref;
     readonly " $refType": FragmentSpread$ref;
-} & ({
-    readonly " $fragmentRefs": UserFrag1$ref & UserFrag2$ref;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 type PageFragment$ref = any;
 export type ConcreateTypes$ref = any;
 export type ConcreateTypes = {
     readonly actor: ({
-        readonly __typename: string;
-        readonly id?: string;
-        readonly name?: string | null;
-        readonly " $fragmentRefs": PageFragment$ref;
-    } & ({
         readonly __typename: "Page";
         readonly id: string;
         readonly " $fragmentRefs": PageFragment$ref;
@@ -1279,10 +1155,10 @@ export type ConcreateTypes = {
         readonly __typename: "User";
         readonly name: string | null;
     } | {
-        /*This will never be '% other', but we need some
+        /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
-    })) | null;
+    }) | null;
     readonly " $refType": ConcreateTypes$ref;
 };
 
@@ -1360,15 +1236,7 @@ export type InlineFragment = {
         readonly text: string | null;
     } | null;
     readonly " $refType": InlineFragment$ref;
-} & ({
-    readonly message: {
-        readonly text: string | null;
-    } | null;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 export type InlineFragmentWithOverlappingFields$ref = any;
@@ -1382,24 +1250,7 @@ export type InlineFragmentWithOverlappingFields = {
     } | null;
     readonly name?: string | null;
     readonly " $refType": InlineFragmentWithOverlappingFields$ref;
-} & ({
-    readonly hometown: {
-        readonly id: string;
-        readonly name: string | null;
-    } | null;
-} | {
-    readonly name: string | null;
-    readonly hometown: {
-        readonly id: string;
-        readonly message: {
-            readonly text: string | null;
-        } | null;
-    } | null;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 export type InlineFragmentConditionalID$ref = any;
@@ -1413,7 +1264,7 @@ export type InlineFragmentConditionalID = {
 type SomeFragment$ref = any;
 export type InlineFragmentKitchenSink$ref = any;
 export type InlineFragmentKitchenSink = {
-    readonly actor: ({
+    readonly actor: {
         readonly id: string;
         readonly profilePicture: {
             readonly uri: string | null;
@@ -1422,14 +1273,7 @@ export type InlineFragmentKitchenSink = {
         } | null;
         readonly name?: string | null;
         readonly " $fragmentRefs": SomeFragment$ref;
-    } & ({
-        readonly name: string | null;
-        readonly " $fragmentRefs": SomeFragment$ref;
-    } | {
-        /*This will never be '% other', but we need some
-        value in case none of the concrete values match.*/
-        readonly __typename: "%other";
-    })) | null;
+    } | null;
     readonly " $refType": InlineFragmentKitchenSink$ref;
 };
 
@@ -1489,16 +1333,13 @@ export type LinkedField = {
 export type UnionTypeTestVariables = {};
 export type UnionTypeTestResponse = {
     readonly neverNode: ({
-        readonly __typename: string;
-        readonly id?: string;
-    } & ({
         readonly __typename: "FakeNode";
         readonly id: string;
     } | {
-        /*This will never be '% other', but we need some
+        /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
-    })) | null;
+    }) | null;
 };
 export type UnionTypeTest = {
     readonly response: UnionTypeTestResponse;
@@ -1538,21 +1379,11 @@ type PlainUserNameRenderer_name$ref = any;
 export type NameRendererFragment$ref = any;
 export type NameRendererFragment = {
     readonly id: string;
-    readonly nameRenderer: ({
+    readonly nameRenderer: {
         readonly __fragmentPropName?: string | null;
         readonly __module_component?: string | null;
         readonly " $fragmentRefs": PlainUserNameRenderer_name$ref & MarkdownUserNameRenderer_name$ref;
-    } & ({
-        readonly __fragmentPropName?: string | null;
-        readonly __module_component: string | null;
-        readonly " $fragmentRefs": PlainUserNameRenderer_name$ref;
-    } | {
-        readonly " $fragmentRefs": MarkdownUserNameRenderer_name$ref;
-    } | {
-        /*This will never be '% other', but we need some
-        value in case none of the concrete values match.*/
-        readonly __typename: "%other";
-    })) | null;
+    } | null;
     readonly " $refType": NameRendererFragment$ref;
 };
 
@@ -1610,21 +1441,11 @@ type PlainUserNameRenderer_name$ref = any;
 export type NameRendererQueryVariables = {};
 export type NameRendererQueryResponse = {
     readonly me: {
-        readonly nameRenderer: ({
+        readonly nameRenderer: {
             readonly __fragmentPropName?: string | null;
             readonly __module_component?: string | null;
             readonly " $fragmentRefs": PlainUserNameRenderer_name$ref & MarkdownUserNameRenderer_name$ref;
-        } & ({
-            readonly __fragmentPropName?: string | null;
-            readonly __module_component: string | null;
-            readonly " $fragmentRefs": PlainUserNameRenderer_name$ref;
-        } | {
-            readonly " $fragmentRefs": MarkdownUserNameRenderer_name$ref;
-        } | {
-            /*This will never be '% other', but we need some
-            value in case none of the concrete values match.*/
-            readonly __typename: "%other";
-        })) | null;
+        } | null;
     } | null;
 };
 export type NameRendererQuery = {
@@ -1931,13 +1752,6 @@ fragment TypenameInsideWithOverlappingFields on Viewer {
 export type TypenameInsideWithOverlappingFields$ref = any;
 export type TypenameInsideWithOverlappingFields = {
     readonly actor: ({
-        readonly __typename: string;
-        readonly id?: string;
-        readonly name?: string | null;
-        readonly profile_picture?: {
-            readonly uri: string | null;
-        } | null;
-    } & ({
         readonly __typename: "Page";
         readonly id: string;
         readonly name: string | null;
@@ -1947,10 +1761,10 @@ export type TypenameInsideWithOverlappingFields = {
             readonly uri: string | null;
         } | null;
     } | {
-        /*This will never be '% other', but we need some
+        /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
-    })) | null;
+    }) | null;
     readonly " $refType": TypenameInsideWithOverlappingFields$ref;
 };
 
@@ -1983,13 +1797,6 @@ fragment TypenameInsideWithOverlappingFieldsFull on Viewer {
 export type TypenameInsideWithOverlappingFieldsFull$ref = any;
 export type TypenameInsideWithOverlappingFieldsFull = {
     readonly actor: ({
-        readonly __typename: string;
-        readonly id?: string;
-        readonly name?: string | null;
-        readonly profile_picture?: {
-            readonly uri: string | null;
-        } | null;
-    } & ({
         readonly __typename: "Page";
         readonly id: string;
         readonly name: string | null;
@@ -1999,10 +1806,10 @@ export type TypenameInsideWithOverlappingFieldsFull = {
             readonly uri: string | null;
         } | null;
     } | {
-        /*This will never be '% other', but we need some
+        /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
-    })) | null;
+    }) | null;
     readonly " $refType": TypenameInsideWithOverlappingFieldsFull$ref;
 };
 
@@ -2096,39 +1903,35 @@ fragment TypenameAliases on Actor {
 export type TypenameInside$ref = any;
 export type TypenameInside = {
     readonly __typename: "User";
-    readonly firstName?: string | null;
-    readonly username?: string | null;
-    readonly " $refType": TypenameInside$ref;
-} & ({
-    readonly __typename: "User";
     readonly firstName: string | null;
+    readonly " $refType": TypenameInside$ref;
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
+    readonly " $refType": TypenameInside$ref;
 } | {
-    /*This will never be '% other', but we need some
+    /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-});
+    readonly " $refType": TypenameInside$ref;
+};
 
 
 export type TypenameOutside$ref = any;
 export type TypenameOutside = {
-    readonly __typename: string;
-    readonly firstName?: string | null;
-    readonly username?: string | null;
-    readonly " $refType": TypenameOutside$ref;
-} & ({
     readonly __typename: "User";
     readonly firstName: string | null;
+    readonly " $refType": TypenameOutside$ref;
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
+    readonly " $refType": TypenameOutside$ref;
 } | {
-    /*This will never be '% other', but we need some
+    /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-});
+    readonly " $refType": TypenameOutside$ref;
+};
 
 
 export type TypenameOutsideWithAbstractType$ref = any;
@@ -2142,18 +1945,7 @@ export type TypenameOutsideWithAbstractType = {
     } | null;
     readonly firstName?: string | null;
     readonly " $refType": TypenameOutsideWithAbstractType$ref;
-} & ({
-    readonly __typename: "User";
-    readonly firstName: string | null;
-    readonly address: {
-        readonly street: string | null;
-        readonly city: string | null;
-    } | null;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 export type TypenameWithoutSpreads$ref = any;
@@ -2161,13 +1953,7 @@ export type TypenameWithoutSpreads = {
     readonly firstName: string | null;
     readonly __typename: "User";
     readonly " $refType": TypenameWithoutSpreads$ref;
-} & ({
-    readonly __typename: "User";
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 export type TypenameWithoutSpreadsAbstractType$ref = any;
@@ -2185,58 +1971,46 @@ export type TypenameWithCommonSelections = {
     readonly firstName?: string | null;
     readonly username?: string | null;
     readonly " $refType": TypenameWithCommonSelections$ref;
-} & ({
-    readonly __typename: "User";
-    readonly firstName: string | null;
-} | {
-    readonly __typename: "Page";
-    readonly username: string | null;
-} | {
-    /*This will never be '% other', but we need some
-    value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+};
 
 
 export type TypenameAlias$ref = any;
 export type TypenameAlias = {
-    readonly _typeAlias: string;
-    readonly firstName?: string | null;
-    readonly username?: string | null;
-    readonly " $refType": TypenameAlias$ref;
-} & ({
     readonly _typeAlias: "User";
     readonly firstName: string | null;
+    readonly " $refType": TypenameAlias$ref;
 } | {
     readonly _typeAlias: "Page";
     readonly username: string | null;
+    readonly " $refType": TypenameAlias$ref;
 } | {
-    /*This will never be '% other', but we need some
+    /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+    readonly _typeAlias: "%other";
+    readonly " $refType": TypenameAlias$ref;
+};
 
 
 export type TypenameAliases$ref = any;
 export type TypenameAliases = {
-    readonly _typeAlias1: string;
-    readonly _typeAlias2: string;
-    readonly firstName?: string | null;
-    readonly username?: string | null;
-    readonly " $refType": TypenameAliases$ref;
-} & ({
     readonly _typeAlias1: "User";
     readonly _typeAlias2: "User";
     readonly firstName: string | null;
+    readonly " $refType": TypenameAliases$ref;
 } | {
     readonly _typeAlias1: "Page";
     readonly _typeAlias2: "Page";
     readonly username: string | null;
+    readonly " $refType": TypenameAliases$ref;
 } | {
-    /*This will never be '% other', but we need some
+    /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
-    readonly __typename: "%other";
-});
+    readonly _typeAlias1: "%other";
+    /*This will never be '%other', but we need some
+    value in case none of the concrete values match.*/
+    readonly _typeAlias2: "%other";
+    readonly " $refType": TypenameAliases$ref;
+};
 
 `;
 

--- a/test/__snapshots__/TypeScriptGenerator-test.ts.snap
+++ b/test/__snapshots__/TypeScriptGenerator-test.ts.snap
@@ -711,6 +711,8 @@ export type TypenameInsideWithOverlappingFields = {
         readonly name: string | null;
     } | {
         readonly __typename: "User";
+        readonly id: string;
+        readonly name: string | null;
         readonly profile_picture: {
             readonly uri: string | null;
         } | null;
@@ -757,9 +759,15 @@ export type TypenameInsideWithOverlappingFieldsFull = {
         readonly name: string | null;
     } | {
         readonly __typename: "User";
+        readonly id: string;
+        readonly name: string | null;
         readonly profile_picture: {
             readonly uri: string | null;
         } | null;
+    } | {
+        readonly __typename: "ExtraUser";
+        readonly id: string;
+        readonly name: string | null;
     } | {
         /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
@@ -1051,7 +1059,6 @@ export type RecursiveFragment$ref = typeof _RecursiveFragment$ref;
 export type RecursiveFragment = {
     readonly uri: string | null;
     readonly width: number | null;
-    readonly " $refType": RecursiveFragment$ref;
 };
 
 
@@ -1757,6 +1764,8 @@ export type TypenameInsideWithOverlappingFields = {
         readonly name: string | null;
     } | {
         readonly __typename: "User";
+        readonly id: string;
+        readonly name: string | null;
         readonly profile_picture: {
             readonly uri: string | null;
         } | null;
@@ -1802,9 +1811,15 @@ export type TypenameInsideWithOverlappingFieldsFull = {
         readonly name: string | null;
     } | {
         readonly __typename: "User";
+        readonly id: string;
+        readonly name: string | null;
         readonly profile_picture: {
             readonly uri: string | null;
         } | null;
+    } | {
+        readonly __typename: "ExtraUser";
+        readonly id: string;
+        readonly name: string | null;
     } | {
         /*This will never be '%other', but we need some
         value in case none of the concrete values match.*/
@@ -2084,7 +2099,6 @@ export type RecursiveFragment$ref = any;
 export type RecursiveFragment = {
     readonly uri: string | null;
     readonly width: number | null;
-    readonly " $refType": RecursiveFragment$ref;
 };
 
 

--- a/types/relay-compiler/core/GraphQLIR.d.ts
+++ b/types/relay-compiler/core/GraphQLIR.d.ts
@@ -83,6 +83,7 @@ export type IR =
   | InlineFragment
   | LinkedField
   | ListValue
+  | ModuleImport
   | Literal
   | LocalArgumentDefinition
   | ObjectFieldValue
@@ -120,6 +121,10 @@ export type LinkedField = {
   name: string;
   selections: Selection[];
   type: GraphQLOutputType;
+};
+export type ModuleImport = {
+  name: string;
+  selections: Selection[];
 };
 export type ListValue = {
   kind: "ListValue";

--- a/types/relay-compiler/language/RelayLanguagePluginInterface.d.ts
+++ b/types/relay-compiler/language/RelayLanguagePluginInterface.d.ts
@@ -37,7 +37,7 @@ export type GraphQLTagFinder = (text: string, filePath: string) => GraphQLTag[];
 export interface TypeGeneratorOptions {
   readonly customScalars: { [type: string]: string };
   readonly useHaste: boolean;
-  readonly enumsHasteModule: string | null;
+  readonly enumsHasteModule: string | ((enumName: string) => string) | null;
   readonly existingFragmentNames: Set<string>;
   readonly optionalInputFields: ReadonlyArray<string>;
   readonly relayRuntimeModule: string;


### PR DESCRIPTION
See the changes in the tests. This should allow much easier work with
types that can take many different shapes.

I assume this will fix #120.