### PR TITLE
Fix opaque types

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,6 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
-  }
+  },
+  "prettier": {}
 }

--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -1,10 +1,8 @@
 import {
   Condition,
-  Directive,
   Fragment,
   IRVisitor,
   LinkedField,
-  Metadata,
   Root,
   ScalarField,
   SchemaUtils,
@@ -32,6 +30,7 @@ const { isAbstractType } = SchemaUtils;
 
 const REF_TYPE = " $refType";
 const FRAGMENT_REFS = " $fragmentRefs";
+const FRAGMENT_REFS_TYPE_NAME = "FragmentRefs";
 const MODULE_IMPORT_FIELD = "MODULE_IMPORT_FIELD";
 const DIRECTIVE_NAME = "raw_response_type";
 
@@ -205,9 +204,8 @@ function selectionsToAST(
       props.push(
         readOnlyObjectTypeProperty(
           REF_TYPE,
-          ts.createTypeReferenceNode(
-            ts.createIdentifier(fragmentTypeName),
-            undefined
+          ts.createLiteralTypeNode(
+            ts.createStringLiteral(`${fragmentTypeName}$ref`)
           )
         )
       );
@@ -303,16 +301,6 @@ function exportType(name: string, type: ts.TypeNode) {
   );
 }
 
-function exportTypes(types: string[]) {
-  return ts.createExportDeclaration(
-    undefined,
-    undefined,
-    ts.createNamedExports(
-      types.map(type => ts.createExportSpecifier(undefined, type))
-    )
-  );
-}
-
 function importTypes(names: string[], fromModule: string): ts.Statement {
   return ts.createImportDeclaration(
     undefined,
@@ -381,14 +369,8 @@ function createVisitor(options: TypeGeneratorOptions): IRVisitor.NodeVisitor {
             createRawResponseTypeVisitor(state)
           );
         }
-        const refetchableFragmentName = getRefetchableQueryParentFragmentName(
-          state,
-          node.metadata
-        );
         const nodes = [
-          ...(refetchableFragmentName
-            ? generateFragmentRefsForRefetchable(refetchableFragmentName)
-            : getFragmentImports(state)),
+          ...getFragmentDeclarations(state),
           ...getEnumDefinitions(state),
           ...inputObjectTypes,
           inputVariablesType,
@@ -444,17 +426,12 @@ function createVisitor(options: TypeGeneratorOptions): IRVisitor.NodeVisitor {
           return [selection];
         });
         state.generatedFragments.add(node.name);
-        const fragmentTypes = getFragmentTypes(
-          node.name,
-          getRefetchableQueryPath(state, node.directives),
-          state
-        );
         const unmasked = node.metadata != null && node.metadata.mask === false;
         const baseType = selectionsToAST(
           selections,
           state,
           unmasked,
-          unmasked ? undefined : getOldFragmentTypeName(node.name)
+          unmasked ? undefined : node.name
         );
         const type = isPlural(node)
           ? ts.createTypeReferenceNode(ts.createIdentifier("ReadonlyArray"), [
@@ -462,12 +439,7 @@ function createVisitor(options: TypeGeneratorOptions): IRVisitor.NodeVisitor {
             ])
           : baseType;
 
-        return [
-          ...getFragmentImports(state),
-          ...getEnumDefinitions(state),
-          ...fragmentTypes,
-          exportType(node.name, type)
-        ];
+        return [...getEnumDefinitions(state), exportType(node.name, type)];
       },
       InlineFragment(node) {
         const typeCondition = node.typeCondition;
@@ -831,61 +803,6 @@ function generateInputVariablesType(node: Root, state: State) {
   );
 }
 
-// If it's a @refetchable fragment, we generate the $fragmentRef in generated
-// query, and import it in the fragment to avoid circular dependencies
-function getRefetchableQueryParentFragmentName(
-  state: State,
-  metadata: Metadata
-): string | null {
-  if (
-    !(metadata && metadata.isRefetchableQuery) ||
-    (!state.useHaste && !state.useSingleArtifactDirectory)
-  ) {
-    return null;
-  }
-  const derivedFrom = metadata && metadata.derivedFrom;
-  if (derivedFrom != null && typeof derivedFrom === "string") {
-    return derivedFrom;
-  }
-  return null;
-}
-
-function getRefetchableQueryPath(
-  state: State,
-  directives: ReadonlyArray<Directive>
-): string | undefined {
-  let refetchableQuery: string | undefined;
-  if (!state.useHaste && !state.useSingleArtifactDirectory) {
-    return;
-  }
-  const directive = directives.find(d => d.name === "refetchable");
-  const refetchableArgs = directive && directive.args;
-  if (!refetchableArgs) {
-    return;
-  }
-  const argument = refetchableArgs.find(
-    arg => arg.kind === "Argument" && arg.name === "queryName"
-  );
-  if (
-    argument &&
-    argument.value &&
-    argument.value.kind === "Literal" &&
-    typeof argument.value.value === "string"
-  ) {
-    refetchableQuery = argument.value.value;
-    if (!state.useHaste) {
-      refetchableQuery = "./" + refetchableQuery;
-    }
-    refetchableQuery += ".graphql";
-  }
-  return refetchableQuery;
-}
-
-function generateFragmentRefsForRefetchable(name: string) {
-  const oldFragmentTypeName = getOldFragmentTypeName(name);
-  return declareExportOpaqueType(oldFragmentTypeName);
-}
-
 function groupRefs(props: Selection[]): Selection[] {
   const result: Selection[] = [];
   const refs: string[] = [];
@@ -897,53 +814,23 @@ function groupRefs(props: Selection[]): Selection[] {
     }
   });
   if (refs.length > 0) {
-    const value = ts.createIntersectionTypeNode(
-      refs.map(ref =>
-        ts.createTypeReferenceNode(
-          ts.createIdentifier(getOldFragmentTypeName(ref)),
-          undefined
-        )
-      )
+    const refTypes = ts.createUnionTypeNode(
+      refs.map(ref => ts.createLiteralTypeNode(ts.createStringLiteral(ref)))
     );
     result.push({
       key: FRAGMENT_REFS,
       conditional: false,
-      value
+      value: ts.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [refTypes])
     });
   }
   return result;
 }
 
-function createAnyTypeAlias(name: string): ts.TypeAliasDeclaration {
-  return ts.createTypeAliasDeclaration(
-    undefined,
-    undefined,
-    ts.createIdentifier(name),
-    undefined,
-    ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)
-  );
-}
-
-function getFragmentImports(state: State) {
-  const imports: ts.Statement[] = [];
+function getFragmentDeclarations(state: State): ts.Statement[] {
   if (state.usedFragments.size > 0) {
-    const usedFragments = Array.from(state.usedFragments).sort();
-    for (const usedFragment of usedFragments) {
-      const fragmentTypeName = getOldFragmentTypeName(usedFragment);
-      if (
-        !state.generatedFragments.has(usedFragment) &&
-        state.useSingleArtifactDirectory &&
-        state.existingFragmentNames.has(usedFragment)
-      ) {
-        imports.push(
-          importTypes([fragmentTypeName], `./${usedFragment}.graphql`)
-        );
-      } else {
-        imports.push(createAnyTypeAlias(fragmentTypeName));
-      }
-    }
+    return [fragmentRefsType];
   }
-  return imports;
+  return [];
 }
 
 function getEnumDefinitions({
@@ -982,62 +869,32 @@ function stringLiteralTypeAnnotation(name: string): ts.TypeNode {
   return ts.createLiteralTypeNode(ts.createLiteral(name));
 }
 
-function getFragmentTypes(
-  name: string,
-  refetchableQueryPath: undefined | string,
-  state: State
-) {
-  const oldFragmentTypeName = getOldFragmentTypeName(name);
-
-  if (!state.useSingleArtifactDirectory && !state.useHaste) {
-    return [
-      exportType(
-        oldFragmentTypeName,
-        ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)
-      )
-    ];
-  }
-
-  if (refetchableQueryPath) {
-    return [
-      importTypes([oldFragmentTypeName], refetchableQueryPath),
-      exportTypes([oldFragmentTypeName])
-    ];
-  }
-
-  return declareExportOpaqueType(oldFragmentTypeName);
-}
-
-function declareExportOpaqueType(oldFragmentTypeName: string) {
-  const _refTypeName = `_${oldFragmentTypeName}`;
-  const _refType = ts.createVariableStatement(
-    [ts.createToken(ts.SyntaxKind.DeclareKeyword)],
-    ts.createVariableDeclarationList(
-      [
-        ts.createVariableDeclaration(
-          _refTypeName,
-          ts.createTypeOperatorNode(
-            ts.SyntaxKind.UniqueKeyword,
-            ts.createKeywordTypeNode(ts.SyntaxKind.SymbolKeyword)
-          )
-        )
-      ],
-      ts.NodeFlags.Const
+// type Fragments<Refs extends string> = null | {[ref in Refs]: true}
+const fragmentRefsType = ts.createTypeAliasDeclaration(
+  undefined,
+  undefined,
+  FRAGMENT_REFS_TYPE_NAME,
+  [
+    ts.createTypeParameterDeclaration(
+      "Refs",
+      ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+      undefined
     )
-  );
-
-  return [
-    _refType,
-    exportType(
-      oldFragmentTypeName,
-      ts.createTypeQueryNode(ts.createIdentifier(_refTypeName))
+  ],
+  ts.createUnionTypeNode([
+    ts.createNull(),
+    ts.createMappedTypeNode(
+      undefined,
+      ts.createTypeParameterDeclaration(
+        "ref",
+        ts.createTypeReferenceNode("Refs", undefined),
+        undefined
+      ),
+      undefined,
+      ts.createLiteralTypeNode(ts.createTrue())
     )
-  ];
-}
-
-function getOldFragmentTypeName(name: string) {
-  return `${name}$ref`;
-}
+  ])
+);
 
 // Should match FLOW_TRANSFORMS array
 // https://github.com/facebook/relay/blob/v6.0.0/packages/relay-compiler/language/javascript/RelayFlowGenerator.js#L621-L627

--- a/test/__snapshots__/TypeScriptGenerator-test.ts.snap
+++ b/test/__snapshots__/TypeScriptGenerator-test.ts.snap
@@ -14,20 +14,16 @@ fragment NestedCondition on Node {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // ConditionField.graphql
-declare const _ConditionField$ref: unique symbol;
-export type ConditionField$ref = typeof _ConditionField$ref;
 export type ConditionField = {
     readonly id?: string;
-    readonly " $refType": ConditionField$ref;
+    readonly " $refType": "ConditionField$ref";
 };
 
 
 // NestedCondition.graphql
-declare const _NestedCondition$ref: unique symbol;
-export type NestedCondition$ref = typeof _NestedCondition$ref;
 export type NestedCondition = {
     readonly id?: string;
-    readonly " $refType": NestedCondition$ref;
+    readonly " $refType": "NestedCondition$ref";
 };
 
 `;
@@ -56,13 +52,15 @@ fragment FeedbackComments_feedback on Feedback {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // QueryWithConnectionField.graphql
-type FeedbackComments_feedback$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type QueryWithConnectionFieldVariables = {
     readonly id: string;
 };
 export type QueryWithConnectionFieldResponse = {
     readonly feedback: {
-        readonly " $fragmentRefs": FeedbackComments_feedback$ref;
+        readonly " $fragmentRefs": FragmentRefs<"FeedbackComments_feedback">;
     } | null;
 };
 export type QueryWithConnectionField = {
@@ -72,8 +70,6 @@ export type QueryWithConnectionField = {
 
 
 // FeedbackComments_feedback.graphql
-declare const _FeedbackComments_feedback$ref: unique symbol;
-export type FeedbackComments_feedback$ref = typeof _FeedbackComments_feedback$ref;
 export type FeedbackComments_feedback = {
     readonly comments: {
         readonly edges: ReadonlyArray<{
@@ -85,7 +81,7 @@ export type FeedbackComments_feedback = {
             readonly hasNextPage: boolean | null;
         } | null;
     } | null;
-    readonly " $refType": FeedbackComments_feedback$ref;
+    readonly " $refType": "FeedbackComments_feedback$ref";
 };
 
 `;
@@ -143,35 +139,26 @@ fragment UserFrag2 on Page {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // FragmentSpread.graphql
-type OtherFragment$ref = any;
-type PictureFragment$ref = any;
-type UserFrag1$ref = any;
-type UserFrag2$ref = any;
-declare const _FragmentSpread$ref: unique symbol;
-export type FragmentSpread$ref = typeof _FragmentSpread$ref;
 export type FragmentSpread = {
     readonly id: string;
     readonly justFrag: {
-        readonly " $fragmentRefs": PictureFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PictureFragment">;
     } | null;
     readonly fragAndField: {
         readonly uri: string | null;
-        readonly " $fragmentRefs": PictureFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PictureFragment">;
     } | null;
-    readonly " $fragmentRefs": OtherFragment$ref & UserFrag1$ref & UserFrag2$ref;
-    readonly " $refType": FragmentSpread$ref;
+    readonly " $fragmentRefs": FragmentRefs<"OtherFragment" | "UserFrag1" | "UserFrag2">;
+    readonly " $refType": "FragmentSpread$ref";
 };
 
 
 // ConcreateTypes.graphql
-type PageFragment$ref = any;
-declare const _ConcreateTypes$ref: unique symbol;
-export type ConcreateTypes$ref = typeof _ConcreateTypes$ref;
 export type ConcreateTypes = {
     readonly actor: ({
         readonly __typename: "Page";
         readonly id: string;
-        readonly " $fragmentRefs": PageFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PageFragment">;
     } | {
         readonly __typename: "User";
         readonly name: string | null;
@@ -180,72 +167,62 @@ export type ConcreateTypes = {
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
     }) | null;
-    readonly " $refType": ConcreateTypes$ref;
+    readonly " $refType": "ConcreateTypes$ref";
 };
 
 
 // PictureFragment.graphql
-declare const _PictureFragment$ref: unique symbol;
-export type PictureFragment$ref = typeof _PictureFragment$ref;
 export type PictureFragment = {
     readonly __typename: "Image";
-    readonly " $refType": PictureFragment$ref;
+    readonly " $refType": "PictureFragment$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": PictureFragment$ref;
+    readonly " $refType": "PictureFragment$ref";
 };
 
 
 // OtherFragment.graphql
-declare const _OtherFragment$ref: unique symbol;
-export type OtherFragment$ref = typeof _OtherFragment$ref;
 export type OtherFragment = {
     readonly __typename: string;
-    readonly " $refType": OtherFragment$ref;
+    readonly " $refType": "OtherFragment$ref";
 };
 
 
 // PageFragment.graphql
-declare const _PageFragment$ref: unique symbol;
-export type PageFragment$ref = typeof _PageFragment$ref;
 export type PageFragment = {
     readonly __typename: "Page";
-    readonly " $refType": PageFragment$ref;
+    readonly " $refType": "PageFragment$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": PageFragment$ref;
+    readonly " $refType": "PageFragment$ref";
 };
 
 
 // UserFrag1.graphql
-declare const _UserFrag1$ref: unique symbol;
-export type UserFrag1$ref = typeof _UserFrag1$ref;
 export type UserFrag1 = {
     readonly __typename: "Page";
-    readonly " $refType": UserFrag1$ref;
+    readonly " $refType": "UserFrag1$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": UserFrag1$ref;
+    readonly " $refType": "UserFrag1$ref";
 };
 
 
 // UserFrag2.graphql
-declare const _UserFrag2$ref: unique symbol;
-export type UserFrag2$ref = typeof _UserFrag2$ref;
 export type UserFrag2 = {
     readonly __typename: "Page";
-    readonly " $refType": UserFrag2$ref;
+    readonly " $refType": "UserFrag2$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": UserFrag2$ref;
+    readonly " $refType": "UserFrag2$ref";
 };
 
 `;
@@ -319,21 +296,17 @@ fragment SomeFragment on User {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // InlineFragment.graphql
-declare const _InlineFragment$ref: unique symbol;
-export type InlineFragment$ref = typeof _InlineFragment$ref;
 export type InlineFragment = {
     readonly id: string;
     readonly name?: string | null;
     readonly message?: {
         readonly text: string | null;
     } | null;
-    readonly " $refType": InlineFragment$ref;
+    readonly " $refType": "InlineFragment$ref";
 };
 
 
 // InlineFragmentWithOverlappingFields.graphql
-declare const _InlineFragmentWithOverlappingFields$ref: unique symbol;
-export type InlineFragmentWithOverlappingFields$ref = typeof _InlineFragmentWithOverlappingFields$ref;
 export type InlineFragmentWithOverlappingFields = {
     readonly hometown?: {
         readonly id: string;
@@ -343,24 +316,19 @@ export type InlineFragmentWithOverlappingFields = {
         } | null;
     } | null;
     readonly name?: string | null;
-    readonly " $refType": InlineFragmentWithOverlappingFields$ref;
+    readonly " $refType": "InlineFragmentWithOverlappingFields$ref";
 };
 
 
 // InlineFragmentConditionalID.graphql
-declare const _InlineFragmentConditionalID$ref: unique symbol;
-export type InlineFragmentConditionalID$ref = typeof _InlineFragmentConditionalID$ref;
 export type InlineFragmentConditionalID = {
     readonly id?: string;
     readonly name?: string | null;
-    readonly " $refType": InlineFragmentConditionalID$ref;
+    readonly " $refType": "InlineFragmentConditionalID$ref";
 };
 
 
 // InlineFragmentKitchenSink.graphql
-type SomeFragment$ref = any;
-declare const _InlineFragmentKitchenSink$ref: unique symbol;
-export type InlineFragmentKitchenSink$ref = typeof _InlineFragmentKitchenSink$ref;
 export type InlineFragmentKitchenSink = {
     readonly actor: {
         readonly id: string;
@@ -370,23 +338,21 @@ export type InlineFragmentKitchenSink = {
             readonly height?: number | null;
         } | null;
         readonly name?: string | null;
-        readonly " $fragmentRefs": SomeFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"SomeFragment">;
     } | null;
-    readonly " $refType": InlineFragmentKitchenSink$ref;
+    readonly " $refType": "InlineFragmentKitchenSink$ref";
 };
 
 
 // SomeFragment.graphql
-declare const _SomeFragment$ref: unique symbol;
-export type SomeFragment$ref = typeof _SomeFragment$ref;
 export type SomeFragment = {
     readonly __typename: "User";
-    readonly " $refType": SomeFragment$ref;
+    readonly " $refType": "SomeFragment$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": SomeFragment$ref;
+    readonly " $refType": "SomeFragment$ref";
 };
 
 `;
@@ -423,8 +389,6 @@ query UnionTypeTest {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // LinkedField.graphql
-declare const _LinkedField$ref: unique symbol;
-export type LinkedField$ref = typeof _LinkedField$ref;
 export type LinkedField = {
     readonly profilePicture: {
         readonly uri: string | null;
@@ -440,7 +404,7 @@ export type LinkedField = {
     readonly actor: {
         readonly id: string;
     } | null;
-    readonly " $refType": LinkedField$ref;
+    readonly " $refType": "LinkedField$ref";
 };
 
 
@@ -490,42 +454,34 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // NameRendererFragment.graphql
-type MarkdownUserNameRenderer_name$ref = any;
-type PlainUserNameRenderer_name$ref = any;
-declare const _NameRendererFragment$ref: unique symbol;
-export type NameRendererFragment$ref = typeof _NameRendererFragment$ref;
 export type NameRendererFragment = {
     readonly id: string;
     readonly nameRenderer: {
         readonly __fragmentPropName?: string | null;
         readonly __module_component?: string | null;
-        readonly " $fragmentRefs": PlainUserNameRenderer_name$ref & MarkdownUserNameRenderer_name$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name">;
     } | null;
-    readonly " $refType": NameRendererFragment$ref;
+    readonly " $refType": "NameRendererFragment$ref";
 };
 
 
 // PlainUserNameRenderer_name.graphql
-declare const _PlainUserNameRenderer_name$ref: unique symbol;
-export type PlainUserNameRenderer_name$ref = typeof _PlainUserNameRenderer_name$ref;
 export type PlainUserNameRenderer_name = {
     readonly plaintext: string | null;
     readonly data: {
         readonly text: string | null;
     } | null;
-    readonly " $refType": PlainUserNameRenderer_name$ref;
+    readonly " $refType": "PlainUserNameRenderer_name$ref";
 };
 
 
 // MarkdownUserNameRenderer_name.graphql
-declare const _MarkdownUserNameRenderer_name$ref: unique symbol;
-export type MarkdownUserNameRenderer_name$ref = typeof _MarkdownUserNameRenderer_name$ref;
 export type MarkdownUserNameRenderer_name = {
     readonly markdown: string | null;
     readonly data: {
         readonly markup: string | null;
     } | null;
-    readonly " $refType": MarkdownUserNameRenderer_name$ref;
+    readonly " $refType": "MarkdownUserNameRenderer_name$ref";
 };
 
 `;
@@ -558,15 +514,16 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // NameRendererQuery.graphql
-type MarkdownUserNameRenderer_name$ref = any;
-type PlainUserNameRenderer_name$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type NameRendererQueryVariables = {};
 export type NameRendererQueryResponse = {
     readonly me: {
         readonly nameRenderer: {
             readonly __fragmentPropName?: string | null;
             readonly __module_component?: string | null;
-            readonly " $fragmentRefs": PlainUserNameRenderer_name$ref & MarkdownUserNameRenderer_name$ref;
+            readonly " $fragmentRefs": FragmentRefs<"PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name">;
         } | null;
     } | null;
 };
@@ -577,26 +534,22 @@ export type NameRendererQuery = {
 
 
 // PlainUserNameRenderer_name.graphql
-declare const _PlainUserNameRenderer_name$ref: unique symbol;
-export type PlainUserNameRenderer_name$ref = typeof _PlainUserNameRenderer_name$ref;
 export type PlainUserNameRenderer_name = {
     readonly plaintext: string | null;
     readonly data: {
         readonly text: string | null;
     } | null;
-    readonly " $refType": PlainUserNameRenderer_name$ref;
+    readonly " $refType": "PlainUserNameRenderer_name$ref";
 };
 
 
 // MarkdownUserNameRenderer_name.graphql
-declare const _MarkdownUserNameRenderer_name$ref: unique symbol;
-export type MarkdownUserNameRenderer_name$ref = typeof _MarkdownUserNameRenderer_name$ref;
 export type MarkdownUserNameRenderer_name = {
     readonly markdown: string | null;
     readonly data: {
         readonly markup: string | null;
     } | null;
-    readonly " $refType": MarkdownUserNameRenderer_name$ref;
+    readonly " $refType": "MarkdownUserNameRenderer_name$ref";
 };
 
 `;
@@ -689,7 +642,9 @@ fragment InlineFragmentWithOverlappingFields on Actor {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // TestMutation.graphql
-type InlineFragmentWithOverlappingFields$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type CommentCreateInput = {
     readonly clientMutationId?: string | null;
     readonly feedbackId?: string | null;
@@ -708,7 +663,7 @@ export type TestMutationResponse = {
     readonly commentCreate: {
         readonly viewer: {
             readonly actor: {
-                readonly " $fragmentRefs": InlineFragmentWithOverlappingFields$ref;
+                readonly " $fragmentRefs": FragmentRefs<"InlineFragmentWithOverlappingFields">;
             } | null;
         } | null;
     } | null;
@@ -748,8 +703,6 @@ export type TestMutation = {
 
 
 // InlineFragmentWithOverlappingFields.graphql
-declare const _InlineFragmentWithOverlappingFields$ref: unique symbol;
-export type InlineFragmentWithOverlappingFields$ref = typeof _InlineFragmentWithOverlappingFields$ref;
 export type InlineFragmentWithOverlappingFields = {
     readonly hometown?: {
         readonly id: string;
@@ -759,7 +712,7 @@ export type InlineFragmentWithOverlappingFields = {
         } | null;
     } | null;
     readonly name?: string | null;
-    readonly " $refType": InlineFragmentWithOverlappingFields$ref;
+    readonly " $refType": "InlineFragmentWithOverlappingFields$ref";
 };
 
 `;
@@ -892,7 +845,9 @@ fragment FriendFragment on User {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // CommentCreateMutation.graphql
-type FriendFragment$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type TestEnums = "mark" | "zuck" | "%future added value";
 export type CommentCreateInput = {
     readonly clientMutationId?: string | null;
@@ -918,7 +873,7 @@ export type CommentCreateMutationResponse = {
                     readonly node: {
                         readonly id: string;
                         readonly __typename: string;
-                        readonly " $fragmentRefs": FriendFragment$ref;
+                        readonly " $fragmentRefs": FragmentRefs<"FriendFragment">;
                     } | null;
                 } | null> | null;
             } | null;
@@ -954,15 +909,13 @@ export type CommentCreateMutation = {
 
 // FriendFragment.graphql
 export type TestEnums = "mark" | "zuck" | "%future added value";
-declare const _FriendFragment$ref: unique symbol;
-export type FriendFragment$ref = typeof _FriendFragment$ref;
 export type FriendFragment = {
     readonly name: string | null;
     readonly lastName: string | null;
     readonly profilePicture2: {
         readonly test_enums: TestEnums | null;
     } | null;
-    readonly " $refType": FriendFragment$ref;
+    readonly " $refType": "FriendFragment$ref";
 };
 
 `;
@@ -1003,7 +956,9 @@ fragment FeedbackFragment on Feedback {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // CommentCreateMutation.graphql
-type FriendFragment$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type CommentCreateInput = {
     readonly clientMutationId?: string | null;
     readonly feedbackId?: string | null;
@@ -1027,7 +982,7 @@ export type CommentCreateMutationResponse = {
                 readonly edges: ReadonlyArray<{
                     readonly node: {
                         readonly lastName: string | null;
-                        readonly " $fragmentRefs": FriendFragment$ref;
+                        readonly " $fragmentRefs": FragmentRefs<"FriendFragment">;
                     } | null;
                 } | null> | null;
             } | null;
@@ -1062,26 +1017,21 @@ export type CommentCreateMutation = {
 
 
 // FriendFragment.graphql
-type FeedbackFragment$ref = any;
-declare const _FriendFragment$ref: unique symbol;
-export type FriendFragment$ref = typeof _FriendFragment$ref;
 export type FriendFragment = {
     readonly name: string | null;
     readonly lastName: string | null;
     readonly feedback: {
-        readonly " $fragmentRefs": FeedbackFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"FeedbackFragment">;
     } | null;
-    readonly " $refType": FriendFragment$ref;
+    readonly " $refType": "FriendFragment$ref";
 };
 
 
 // FeedbackFragment.graphql
-declare const _FeedbackFragment$ref: unique symbol;
-export type FeedbackFragment$ref = typeof _FeedbackFragment$ref;
 export type FeedbackFragment = {
     readonly id: string;
     readonly name: string | null;
-    readonly " $refType": FeedbackFragment$ref;
+    readonly " $refType": "FeedbackFragment$ref";
 };
 
 `;
@@ -1094,11 +1044,9 @@ fragment PluralFragment on Node @relay(plural: true) {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // PluralFragment.graphql
-declare const _PluralFragment$ref: unique symbol;
-export type PluralFragment$ref = typeof _PluralFragment$ref;
 export type PluralFragment = ReadonlyArray<{
     readonly id: string;
-    readonly " $refType": PluralFragment$ref;
+    readonly " $refType": "PluralFragment$ref";
 }>;
 
 `;
@@ -1264,14 +1212,16 @@ fragment FriendFragment on User {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // ExampleQuery.graphql
-type FriendFragment$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type ExampleQueryVariables = {
     readonly id: string;
     readonly condition: boolean;
 };
 export type ExampleQueryResponse = {
     readonly node: {
-        readonly " $fragmentRefs": FriendFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"FriendFragment">;
     } | null;
 };
 export type ExampleQueryRawResponse = {
@@ -1297,8 +1247,6 @@ export type ExampleQuery = {
 
 
 // FriendFragment.graphql
-declare const _FriendFragment$ref: unique symbol;
-export type FriendFragment$ref = typeof _FriendFragment$ref;
 export type FriendFragment = {
     readonly name?: string | null;
     readonly lastName?: string | null;
@@ -1306,7 +1254,7 @@ export type FriendFragment = {
         readonly id: string;
         readonly name: string | null;
     } | null;
-    readonly " $refType": FriendFragment$ref;
+    readonly " $refType": "FriendFragment$ref";
 };
 
 `;
@@ -1389,13 +1337,10 @@ fragment FragmentSpread on Node {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // FragmentSpread.graphql
-type FragmentSpread$ref = any;
-declare const _FragmentSpread$ref: unique symbol;
-export type FragmentSpread$ref = typeof _FragmentSpread$ref;
 export type FragmentSpread = {
     readonly id: string;
-    readonly " $fragmentRefs": FragmentSpread$ref;
-    readonly " $refType": FragmentSpread$ref;
+    readonly " $fragmentRefs": FragmentRefs<"FragmentSpread">;
+    readonly " $refType": "FragmentSpread$ref";
 };
 
 `;
@@ -1412,26 +1357,25 @@ fragment RefetchableFragment on Node
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // RefetchableFragment.graphql
-import { RefetchableFragment$ref } from "./RefetchableFragmentQuery.graphql";
-export { RefetchableFragment$ref };
 export type RefetchableFragment = {
     readonly id: string;
     readonly fragAndField: {
         readonly uri: string | null;
     } | null;
-    readonly " $refType": RefetchableFragment$ref;
+    readonly " $refType": "RefetchableFragment$ref";
 };
 
 
 // RefetchableFragmentQuery.graphql
-declare const _RefetchableFragment$ref: unique symbol;
-export type RefetchableFragment$ref = typeof _RefetchableFragment$ref;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type RefetchableFragmentQueryVariables = {
     readonly id: string;
 };
 export type RefetchableFragmentQueryResponse = {
     readonly node: {
-        readonly " $fragmentRefs": RefetchableFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"RefetchableFragment">;
     } | null;
 };
 export type RefetchableFragmentQuery = {
@@ -1486,11 +1430,9 @@ export type ExampleQuery = {
 
 
 // ExampleFragment.graphql
-declare const _ExampleFragment$ref: unique symbol;
-export type ExampleFragment$ref = typeof _ExampleFragment$ref;
 export type ExampleFragment = {
     readonly id: string;
-    readonly " $refType": ExampleFragment$ref;
+    readonly " $refType": "ExampleFragment$ref";
 };
 
 
@@ -1563,8 +1505,6 @@ fragment ScalarField on User {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // ScalarField.graphql
 export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value";
-declare const _ScalarField$ref: unique symbol;
-export type ScalarField$ref = typeof _ScalarField$ref;
 export type ScalarField = {
     readonly id: string;
     readonly name: string | null;
@@ -1577,7 +1517,7 @@ export type ScalarField = {
         readonly name: string | null;
         readonly service: string | null;
     } | null> | null;
-    readonly " $refType": ScalarField$ref;
+    readonly " $refType": "ScalarField$ref";
 };
 
 `;
@@ -1603,8 +1543,6 @@ fragment TypenameInsideWithOverlappingFields on Viewer {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // TypenameInsideWithOverlappingFields.graphql
-declare const _TypenameInsideWithOverlappingFields$ref: unique symbol;
-export type TypenameInsideWithOverlappingFields$ref = typeof _TypenameInsideWithOverlappingFields$ref;
 export type TypenameInsideWithOverlappingFields = {
     readonly actor: ({
         readonly __typename: "Page";
@@ -1622,7 +1560,7 @@ export type TypenameInsideWithOverlappingFields = {
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
     }) | null;
-    readonly " $refType": TypenameInsideWithOverlappingFields$ref;
+    readonly " $refType": "TypenameInsideWithOverlappingFields$ref";
 };
 
 `;
@@ -1712,46 +1650,40 @@ fragment TypenameAliases on Actor {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // TypenameInside.graphql
-declare const _TypenameInside$ref: unique symbol;
-export type TypenameInside$ref = typeof _TypenameInside$ref;
 export type TypenameInside = {
     readonly __typename: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameInside$ref;
+    readonly " $refType": "TypenameInside$ref";
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameInside$ref;
+    readonly " $refType": "TypenameInside$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": TypenameInside$ref;
+    readonly " $refType": "TypenameInside$ref";
 };
 
 
 // TypenameOutside.graphql
-declare const _TypenameOutside$ref: unique symbol;
-export type TypenameOutside$ref = typeof _TypenameOutside$ref;
 export type TypenameOutside = {
     readonly __typename: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameOutside$ref;
+    readonly " $refType": "TypenameOutside$ref";
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameOutside$ref;
+    readonly " $refType": "TypenameOutside$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": TypenameOutside$ref;
+    readonly " $refType": "TypenameOutside$ref";
 };
 
 
 // TypenameOutsideWithAbstractType.graphql
-declare const _TypenameOutsideWithAbstractType$ref: unique symbol;
-export type TypenameOutsideWithAbstractType$ref = typeof _TypenameOutsideWithAbstractType$ref;
 export type TypenameOutsideWithAbstractType = {
     readonly __typename: string;
     readonly username?: string | null;
@@ -1761,74 +1693,64 @@ export type TypenameOutsideWithAbstractType = {
         readonly street?: string | null;
     } | null;
     readonly firstName?: string | null;
-    readonly " $refType": TypenameOutsideWithAbstractType$ref;
+    readonly " $refType": "TypenameOutsideWithAbstractType$ref";
 };
 
 
 // TypenameWithoutSpreads.graphql
-declare const _TypenameWithoutSpreads$ref: unique symbol;
-export type TypenameWithoutSpreads$ref = typeof _TypenameWithoutSpreads$ref;
 export type TypenameWithoutSpreads = {
     readonly firstName: string | null;
     readonly __typename: "User";
-    readonly " $refType": TypenameWithoutSpreads$ref;
+    readonly " $refType": "TypenameWithoutSpreads$ref";
 };
 
 
 // TypenameWithoutSpreadsAbstractType.graphql
-declare const _TypenameWithoutSpreadsAbstractType$ref: unique symbol;
-export type TypenameWithoutSpreadsAbstractType$ref = typeof _TypenameWithoutSpreadsAbstractType$ref;
 export type TypenameWithoutSpreadsAbstractType = {
     readonly __typename: string;
     readonly id: string;
-    readonly " $refType": TypenameWithoutSpreadsAbstractType$ref;
+    readonly " $refType": "TypenameWithoutSpreadsAbstractType$ref";
 };
 
 
 // TypenameWithCommonSelections.graphql
-declare const _TypenameWithCommonSelections$ref: unique symbol;
-export type TypenameWithCommonSelections$ref = typeof _TypenameWithCommonSelections$ref;
 export type TypenameWithCommonSelections = {
     readonly __typename: string;
     readonly name: string | null;
     readonly firstName?: string | null;
     readonly username?: string | null;
-    readonly " $refType": TypenameWithCommonSelections$ref;
+    readonly " $refType": "TypenameWithCommonSelections$ref";
 };
 
 
 // TypenameAlias.graphql
-declare const _TypenameAlias$ref: unique symbol;
-export type TypenameAlias$ref = typeof _TypenameAlias$ref;
 export type TypenameAlias = {
     readonly _typeAlias: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameAlias$ref;
+    readonly " $refType": "TypenameAlias$ref";
 } | {
     readonly _typeAlias: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameAlias$ref;
+    readonly " $refType": "TypenameAlias$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly _typeAlias: "%other";
-    readonly " $refType": TypenameAlias$ref;
+    readonly " $refType": "TypenameAlias$ref";
 };
 
 
 // TypenameAliases.graphql
-declare const _TypenameAliases$ref: unique symbol;
-export type TypenameAliases$ref = typeof _TypenameAliases$ref;
 export type TypenameAliases = {
     readonly _typeAlias1: "User";
     readonly _typeAlias2: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameAliases$ref;
+    readonly " $refType": "TypenameAliases$ref";
 } | {
     readonly _typeAlias1: "Page";
     readonly _typeAlias2: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameAliases$ref;
+    readonly " $refType": "TypenameAliases$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
@@ -1836,7 +1758,7 @@ export type TypenameAliases = {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly _typeAlias2: "%other";
-    readonly " $refType": TypenameAliases$ref;
+    readonly " $refType": "TypenameAliases$ref";
 };
 
 `;
@@ -1872,33 +1794,26 @@ fragment AnotherRecursiveFragment on Image {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // UserProfile.graphql
-import { PhotoFragment$ref } from "./PhotoFragment.graphql";
-declare const _UserProfile$ref: unique symbol;
-export type UserProfile$ref = typeof _UserProfile$ref;
 export type UserProfile = {
     readonly profilePicture: {
         readonly uri: string | null;
         readonly width: number | null;
         readonly height: number | null;
-        readonly " $fragmentRefs": PhotoFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PhotoFragment">;
     } | null;
-    readonly " $refType": UserProfile$ref;
+    readonly " $refType": "UserProfile$ref";
 };
 
 
 // PhotoFragment.graphql
-declare const _PhotoFragment$ref: unique symbol;
-export type PhotoFragment$ref = typeof _PhotoFragment$ref;
 export type PhotoFragment = {
     readonly uri: string | null;
     readonly width: number | null;
-    readonly " $refType": PhotoFragment$ref;
+    readonly " $refType": "PhotoFragment$ref";
 };
 
 
 // RecursiveFragment.graphql
-declare const _RecursiveFragment$ref: unique symbol;
-export type RecursiveFragment$ref = typeof _RecursiveFragment$ref;
 export type RecursiveFragment = {
     readonly uri: string | null;
     readonly width: number | null;
@@ -1906,12 +1821,10 @@ export type RecursiveFragment = {
 
 
 // AnotherRecursiveFragment.graphql
-declare const _AnotherRecursiveFragment$ref: unique symbol;
-export type AnotherRecursiveFragment$ref = typeof _AnotherRecursiveFragment$ref;
 export type AnotherRecursiveFragment = {
     readonly uri: string | null;
     readonly height: number | null;
-    readonly " $refType": AnotherRecursiveFragment$ref;
+    readonly " $refType": "AnotherRecursiveFragment$ref";
 };
 
 `;
@@ -1930,18 +1843,16 @@ fragment NestedCondition on Node {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // ConditionField.graphql
-export type ConditionField$ref = any;
 export type ConditionField = {
     readonly id?: string;
-    readonly " $refType": ConditionField$ref;
+    readonly " $refType": "ConditionField$ref";
 };
 
 
 // NestedCondition.graphql
-export type NestedCondition$ref = any;
 export type NestedCondition = {
     readonly id?: string;
-    readonly " $refType": NestedCondition$ref;
+    readonly " $refType": "NestedCondition$ref";
 };
 
 `;
@@ -1970,13 +1881,15 @@ fragment FeedbackComments_feedback on Feedback {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // QueryWithConnectionField.graphql
-type FeedbackComments_feedback$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type QueryWithConnectionFieldVariables = {
     readonly id: string;
 };
 export type QueryWithConnectionFieldResponse = {
     readonly feedback: {
-        readonly " $fragmentRefs": FeedbackComments_feedback$ref;
+        readonly " $fragmentRefs": FragmentRefs<"FeedbackComments_feedback">;
     } | null;
 };
 export type QueryWithConnectionField = {
@@ -1986,7 +1899,6 @@ export type QueryWithConnectionField = {
 
 
 // FeedbackComments_feedback.graphql
-export type FeedbackComments_feedback$ref = any;
 export type FeedbackComments_feedback = {
     readonly comments: {
         readonly edges: ReadonlyArray<{
@@ -1998,7 +1910,7 @@ export type FeedbackComments_feedback = {
             readonly hasNextPage: boolean | null;
         } | null;
     } | null;
-    readonly " $refType": FeedbackComments_feedback$ref;
+    readonly " $refType": "FeedbackComments_feedback$ref";
 };
 
 `;
@@ -2056,33 +1968,26 @@ fragment UserFrag2 on Page {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // FragmentSpread.graphql
-type OtherFragment$ref = any;
-type PictureFragment$ref = any;
-type UserFrag1$ref = any;
-type UserFrag2$ref = any;
-export type FragmentSpread$ref = any;
 export type FragmentSpread = {
     readonly id: string;
     readonly justFrag: {
-        readonly " $fragmentRefs": PictureFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PictureFragment">;
     } | null;
     readonly fragAndField: {
         readonly uri: string | null;
-        readonly " $fragmentRefs": PictureFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PictureFragment">;
     } | null;
-    readonly " $fragmentRefs": OtherFragment$ref & UserFrag1$ref & UserFrag2$ref;
-    readonly " $refType": FragmentSpread$ref;
+    readonly " $fragmentRefs": FragmentRefs<"OtherFragment" | "UserFrag1" | "UserFrag2">;
+    readonly " $refType": "FragmentSpread$ref";
 };
 
 
 // ConcreateTypes.graphql
-type PageFragment$ref = any;
-export type ConcreateTypes$ref = any;
 export type ConcreateTypes = {
     readonly actor: ({
         readonly __typename: "Page";
         readonly id: string;
-        readonly " $fragmentRefs": PageFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PageFragment">;
     } | {
         readonly __typename: "User";
         readonly name: string | null;
@@ -2091,67 +1996,62 @@ export type ConcreateTypes = {
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
     }) | null;
-    readonly " $refType": ConcreateTypes$ref;
+    readonly " $refType": "ConcreateTypes$ref";
 };
 
 
 // PictureFragment.graphql
-export type PictureFragment$ref = any;
 export type PictureFragment = {
     readonly __typename: "Image";
-    readonly " $refType": PictureFragment$ref;
+    readonly " $refType": "PictureFragment$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": PictureFragment$ref;
+    readonly " $refType": "PictureFragment$ref";
 };
 
 
 // OtherFragment.graphql
-export type OtherFragment$ref = any;
 export type OtherFragment = {
     readonly __typename: string;
-    readonly " $refType": OtherFragment$ref;
+    readonly " $refType": "OtherFragment$ref";
 };
 
 
 // PageFragment.graphql
-export type PageFragment$ref = any;
 export type PageFragment = {
     readonly __typename: "Page";
-    readonly " $refType": PageFragment$ref;
+    readonly " $refType": "PageFragment$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": PageFragment$ref;
+    readonly " $refType": "PageFragment$ref";
 };
 
 
 // UserFrag1.graphql
-export type UserFrag1$ref = any;
 export type UserFrag1 = {
     readonly __typename: "Page";
-    readonly " $refType": UserFrag1$ref;
+    readonly " $refType": "UserFrag1$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": UserFrag1$ref;
+    readonly " $refType": "UserFrag1$ref";
 };
 
 
 // UserFrag2.graphql
-export type UserFrag2$ref = any;
 export type UserFrag2 = {
     readonly __typename: "Page";
-    readonly " $refType": UserFrag2$ref;
+    readonly " $refType": "UserFrag2$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": UserFrag2$ref;
+    readonly " $refType": "UserFrag2$ref";
 };
 
 `;
@@ -2225,19 +2125,17 @@ fragment SomeFragment on User {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // InlineFragment.graphql
-export type InlineFragment$ref = any;
 export type InlineFragment = {
     readonly id: string;
     readonly name?: string | null;
     readonly message?: {
         readonly text: string | null;
     } | null;
-    readonly " $refType": InlineFragment$ref;
+    readonly " $refType": "InlineFragment$ref";
 };
 
 
 // InlineFragmentWithOverlappingFields.graphql
-export type InlineFragmentWithOverlappingFields$ref = any;
 export type InlineFragmentWithOverlappingFields = {
     readonly hometown?: {
         readonly id: string;
@@ -2247,22 +2145,19 @@ export type InlineFragmentWithOverlappingFields = {
         } | null;
     } | null;
     readonly name?: string | null;
-    readonly " $refType": InlineFragmentWithOverlappingFields$ref;
+    readonly " $refType": "InlineFragmentWithOverlappingFields$ref";
 };
 
 
 // InlineFragmentConditionalID.graphql
-export type InlineFragmentConditionalID$ref = any;
 export type InlineFragmentConditionalID = {
     readonly id?: string;
     readonly name?: string | null;
-    readonly " $refType": InlineFragmentConditionalID$ref;
+    readonly " $refType": "InlineFragmentConditionalID$ref";
 };
 
 
 // InlineFragmentKitchenSink.graphql
-type SomeFragment$ref = any;
-export type InlineFragmentKitchenSink$ref = any;
 export type InlineFragmentKitchenSink = {
     readonly actor: {
         readonly id: string;
@@ -2272,22 +2167,21 @@ export type InlineFragmentKitchenSink = {
             readonly height?: number | null;
         } | null;
         readonly name?: string | null;
-        readonly " $fragmentRefs": SomeFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"SomeFragment">;
     } | null;
-    readonly " $refType": InlineFragmentKitchenSink$ref;
+    readonly " $refType": "InlineFragmentKitchenSink$ref";
 };
 
 
 // SomeFragment.graphql
-export type SomeFragment$ref = any;
 export type SomeFragment = {
     readonly __typename: "User";
-    readonly " $refType": SomeFragment$ref;
+    readonly " $refType": "SomeFragment$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": SomeFragment$ref;
+    readonly " $refType": "SomeFragment$ref";
 };
 
 `;
@@ -2324,7 +2218,6 @@ query UnionTypeTest {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // LinkedField.graphql
-export type LinkedField$ref = any;
 export type LinkedField = {
     readonly profilePicture: {
         readonly uri: string | null;
@@ -2340,7 +2233,7 @@ export type LinkedField = {
     readonly actor: {
         readonly id: string;
     } | null;
-    readonly " $refType": LinkedField$ref;
+    readonly " $refType": "LinkedField$ref";
 };
 
 
@@ -2390,39 +2283,34 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // NameRendererFragment.graphql
-type MarkdownUserNameRenderer_name$ref = any;
-type PlainUserNameRenderer_name$ref = any;
-export type NameRendererFragment$ref = any;
 export type NameRendererFragment = {
     readonly id: string;
     readonly nameRenderer: {
         readonly __fragmentPropName?: string | null;
         readonly __module_component?: string | null;
-        readonly " $fragmentRefs": PlainUserNameRenderer_name$ref & MarkdownUserNameRenderer_name$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name">;
     } | null;
-    readonly " $refType": NameRendererFragment$ref;
+    readonly " $refType": "NameRendererFragment$ref";
 };
 
 
 // PlainUserNameRenderer_name.graphql
-export type PlainUserNameRenderer_name$ref = any;
 export type PlainUserNameRenderer_name = {
     readonly plaintext: string | null;
     readonly data: {
         readonly text: string | null;
     } | null;
-    readonly " $refType": PlainUserNameRenderer_name$ref;
+    readonly " $refType": "PlainUserNameRenderer_name$ref";
 };
 
 
 // MarkdownUserNameRenderer_name.graphql
-export type MarkdownUserNameRenderer_name$ref = any;
 export type MarkdownUserNameRenderer_name = {
     readonly markdown: string | null;
     readonly data: {
         readonly markup: string | null;
     } | null;
-    readonly " $refType": MarkdownUserNameRenderer_name$ref;
+    readonly " $refType": "MarkdownUserNameRenderer_name$ref";
 };
 
 `;
@@ -2455,15 +2343,16 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // NameRendererQuery.graphql
-type MarkdownUserNameRenderer_name$ref = any;
-type PlainUserNameRenderer_name$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type NameRendererQueryVariables = {};
 export type NameRendererQueryResponse = {
     readonly me: {
         readonly nameRenderer: {
             readonly __fragmentPropName?: string | null;
             readonly __module_component?: string | null;
-            readonly " $fragmentRefs": PlainUserNameRenderer_name$ref & MarkdownUserNameRenderer_name$ref;
+            readonly " $fragmentRefs": FragmentRefs<"PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name">;
         } | null;
     } | null;
 };
@@ -2474,24 +2363,22 @@ export type NameRendererQuery = {
 
 
 // PlainUserNameRenderer_name.graphql
-export type PlainUserNameRenderer_name$ref = any;
 export type PlainUserNameRenderer_name = {
     readonly plaintext: string | null;
     readonly data: {
         readonly text: string | null;
     } | null;
-    readonly " $refType": PlainUserNameRenderer_name$ref;
+    readonly " $refType": "PlainUserNameRenderer_name$ref";
 };
 
 
 // MarkdownUserNameRenderer_name.graphql
-export type MarkdownUserNameRenderer_name$ref = any;
 export type MarkdownUserNameRenderer_name = {
     readonly markdown: string | null;
     readonly data: {
         readonly markup: string | null;
     } | null;
-    readonly " $refType": MarkdownUserNameRenderer_name$ref;
+    readonly " $refType": "MarkdownUserNameRenderer_name$ref";
 };
 
 `;
@@ -2584,7 +2471,9 @@ fragment InlineFragmentWithOverlappingFields on Actor {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // TestMutation.graphql
-type InlineFragmentWithOverlappingFields$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type CommentCreateInput = {
     readonly clientMutationId?: string | null;
     readonly feedbackId?: string | null;
@@ -2603,7 +2492,7 @@ export type TestMutationResponse = {
     readonly commentCreate: {
         readonly viewer: {
             readonly actor: {
-                readonly " $fragmentRefs": InlineFragmentWithOverlappingFields$ref;
+                readonly " $fragmentRefs": FragmentRefs<"InlineFragmentWithOverlappingFields">;
             } | null;
         } | null;
     } | null;
@@ -2643,7 +2532,6 @@ export type TestMutation = {
 
 
 // InlineFragmentWithOverlappingFields.graphql
-export type InlineFragmentWithOverlappingFields$ref = any;
 export type InlineFragmentWithOverlappingFields = {
     readonly hometown?: {
         readonly id: string;
@@ -2653,7 +2541,7 @@ export type InlineFragmentWithOverlappingFields = {
         } | null;
     } | null;
     readonly name?: string | null;
-    readonly " $refType": InlineFragmentWithOverlappingFields$ref;
+    readonly " $refType": "InlineFragmentWithOverlappingFields$ref";
 };
 
 `;
@@ -2786,7 +2674,9 @@ fragment FriendFragment on User {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // CommentCreateMutation.graphql
-type FriendFragment$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type TestEnums = "mark" | "zuck" | "%future added value";
 export type CommentCreateInput = {
     readonly clientMutationId?: string | null;
@@ -2812,7 +2702,7 @@ export type CommentCreateMutationResponse = {
                     readonly node: {
                         readonly id: string;
                         readonly __typename: string;
-                        readonly " $fragmentRefs": FriendFragment$ref;
+                        readonly " $fragmentRefs": FragmentRefs<"FriendFragment">;
                     } | null;
                 } | null> | null;
             } | null;
@@ -2848,14 +2738,13 @@ export type CommentCreateMutation = {
 
 // FriendFragment.graphql
 export type TestEnums = "mark" | "zuck" | "%future added value";
-export type FriendFragment$ref = any;
 export type FriendFragment = {
     readonly name: string | null;
     readonly lastName: string | null;
     readonly profilePicture2: {
         readonly test_enums: TestEnums | null;
     } | null;
-    readonly " $refType": FriendFragment$ref;
+    readonly " $refType": "FriendFragment$ref";
 };
 
 `;
@@ -2896,7 +2785,9 @@ fragment FeedbackFragment on Feedback {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // CommentCreateMutation.graphql
-type FriendFragment$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type CommentCreateInput = {
     readonly clientMutationId?: string | null;
     readonly feedbackId?: string | null;
@@ -2920,7 +2811,7 @@ export type CommentCreateMutationResponse = {
                 readonly edges: ReadonlyArray<{
                     readonly node: {
                         readonly lastName: string | null;
-                        readonly " $fragmentRefs": FriendFragment$ref;
+                        readonly " $fragmentRefs": FragmentRefs<"FriendFragment">;
                     } | null;
                 } | null> | null;
             } | null;
@@ -2955,24 +2846,21 @@ export type CommentCreateMutation = {
 
 
 // FriendFragment.graphql
-type FeedbackFragment$ref = any;
-export type FriendFragment$ref = any;
 export type FriendFragment = {
     readonly name: string | null;
     readonly lastName: string | null;
     readonly feedback: {
-        readonly " $fragmentRefs": FeedbackFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"FeedbackFragment">;
     } | null;
-    readonly " $refType": FriendFragment$ref;
+    readonly " $refType": "FriendFragment$ref";
 };
 
 
 // FeedbackFragment.graphql
-export type FeedbackFragment$ref = any;
 export type FeedbackFragment = {
     readonly id: string;
     readonly name: string | null;
-    readonly " $refType": FeedbackFragment$ref;
+    readonly " $refType": "FeedbackFragment$ref";
 };
 
 `;
@@ -2985,10 +2873,9 @@ fragment PluralFragment on Node @relay(plural: true) {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // PluralFragment.graphql
-export type PluralFragment$ref = any;
 export type PluralFragment = ReadonlyArray<{
     readonly id: string;
-    readonly " $refType": PluralFragment$ref;
+    readonly " $refType": "PluralFragment$ref";
 }>;
 
 `;
@@ -3154,14 +3041,16 @@ fragment FriendFragment on User {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // ExampleQuery.graphql
-type FriendFragment$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type ExampleQueryVariables = {
     readonly id: string;
     readonly condition: boolean;
 };
 export type ExampleQueryResponse = {
     readonly node: {
-        readonly " $fragmentRefs": FriendFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"FriendFragment">;
     } | null;
 };
 export type ExampleQueryRawResponse = {
@@ -3187,7 +3076,6 @@ export type ExampleQuery = {
 
 
 // FriendFragment.graphql
-export type FriendFragment$ref = any;
 export type FriendFragment = {
     readonly name?: string | null;
     readonly lastName?: string | null;
@@ -3195,7 +3083,7 @@ export type FriendFragment = {
         readonly id: string;
         readonly name: string | null;
     } | null;
-    readonly " $refType": FriendFragment$ref;
+    readonly " $refType": "FriendFragment$ref";
 };
 
 `;
@@ -3278,12 +3166,10 @@ fragment FragmentSpread on Node {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // FragmentSpread.graphql
-type FragmentSpread$ref = any;
-export type FragmentSpread$ref = any;
 export type FragmentSpread = {
     readonly id: string;
-    readonly " $fragmentRefs": FragmentSpread$ref;
-    readonly " $refType": FragmentSpread$ref;
+    readonly " $fragmentRefs": FragmentRefs<"FragmentSpread">;
+    readonly " $refType": "FragmentSpread$ref";
 };
 
 `;
@@ -3300,24 +3186,25 @@ fragment RefetchableFragment on Node
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // RefetchableFragment.graphql
-export type RefetchableFragment$ref = any;
 export type RefetchableFragment = {
     readonly id: string;
     readonly fragAndField: {
         readonly uri: string | null;
     } | null;
-    readonly " $refType": RefetchableFragment$ref;
+    readonly " $refType": "RefetchableFragment$ref";
 };
 
 
 // RefetchableFragmentQuery.graphql
-type RefetchableFragment$ref = any;
+type FragmentRefs<Refs extends string> = null | {
+    [ref in Refs]: true;
+};
 export type RefetchableFragmentQueryVariables = {
     readonly id: string;
 };
 export type RefetchableFragmentQueryResponse = {
     readonly node: {
-        readonly " $fragmentRefs": RefetchableFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"RefetchableFragment">;
     } | null;
 };
 export type RefetchableFragmentQuery = {
@@ -3372,10 +3259,9 @@ export type ExampleQuery = {
 
 
 // ExampleFragment.graphql
-export type ExampleFragment$ref = any;
 export type ExampleFragment = {
     readonly id: string;
-    readonly " $refType": ExampleFragment$ref;
+    readonly " $refType": "ExampleFragment$ref";
 };
 
 
@@ -3448,7 +3334,6 @@ fragment ScalarField on User {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // ScalarField.graphql
 export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value";
-export type ScalarField$ref = any;
 export type ScalarField = {
     readonly id: string;
     readonly name: string | null;
@@ -3461,7 +3346,7 @@ export type ScalarField = {
         readonly name: string | null;
         readonly service: string | null;
     } | null> | null;
-    readonly " $refType": ScalarField$ref;
+    readonly " $refType": "ScalarField$ref";
 };
 
 `;
@@ -3487,7 +3372,6 @@ fragment TypenameInsideWithOverlappingFields on Viewer {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // TypenameInsideWithOverlappingFields.graphql
-export type TypenameInsideWithOverlappingFields$ref = any;
 export type TypenameInsideWithOverlappingFields = {
     readonly actor: ({
         readonly __typename: "Page";
@@ -3505,7 +3389,7 @@ export type TypenameInsideWithOverlappingFields = {
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
     }) | null;
-    readonly " $refType": TypenameInsideWithOverlappingFields$ref;
+    readonly " $refType": "TypenameInsideWithOverlappingFields$ref";
 };
 
 `;
@@ -3595,43 +3479,40 @@ fragment TypenameAliases on Actor {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // TypenameInside.graphql
-export type TypenameInside$ref = any;
 export type TypenameInside = {
     readonly __typename: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameInside$ref;
+    readonly " $refType": "TypenameInside$ref";
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameInside$ref;
+    readonly " $refType": "TypenameInside$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": TypenameInside$ref;
+    readonly " $refType": "TypenameInside$ref";
 };
 
 
 // TypenameOutside.graphql
-export type TypenameOutside$ref = any;
 export type TypenameOutside = {
     readonly __typename: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameOutside$ref;
+    readonly " $refType": "TypenameOutside$ref";
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameOutside$ref;
+    readonly " $refType": "TypenameOutside$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": TypenameOutside$ref;
+    readonly " $refType": "TypenameOutside$ref";
 };
 
 
 // TypenameOutsideWithAbstractType.graphql
-export type TypenameOutsideWithAbstractType$ref = any;
 export type TypenameOutsideWithAbstractType = {
     readonly __typename: string;
     readonly username?: string | null;
@@ -3641,69 +3522,64 @@ export type TypenameOutsideWithAbstractType = {
         readonly street?: string | null;
     } | null;
     readonly firstName?: string | null;
-    readonly " $refType": TypenameOutsideWithAbstractType$ref;
+    readonly " $refType": "TypenameOutsideWithAbstractType$ref";
 };
 
 
 // TypenameWithoutSpreads.graphql
-export type TypenameWithoutSpreads$ref = any;
 export type TypenameWithoutSpreads = {
     readonly firstName: string | null;
     readonly __typename: "User";
-    readonly " $refType": TypenameWithoutSpreads$ref;
+    readonly " $refType": "TypenameWithoutSpreads$ref";
 };
 
 
 // TypenameWithoutSpreadsAbstractType.graphql
-export type TypenameWithoutSpreadsAbstractType$ref = any;
 export type TypenameWithoutSpreadsAbstractType = {
     readonly __typename: string;
     readonly id: string;
-    readonly " $refType": TypenameWithoutSpreadsAbstractType$ref;
+    readonly " $refType": "TypenameWithoutSpreadsAbstractType$ref";
 };
 
 
 // TypenameWithCommonSelections.graphql
-export type TypenameWithCommonSelections$ref = any;
 export type TypenameWithCommonSelections = {
     readonly __typename: string;
     readonly name: string | null;
     readonly firstName?: string | null;
     readonly username?: string | null;
-    readonly " $refType": TypenameWithCommonSelections$ref;
+    readonly " $refType": "TypenameWithCommonSelections$ref";
 };
 
 
 // TypenameAlias.graphql
-export type TypenameAlias$ref = any;
 export type TypenameAlias = {
     readonly _typeAlias: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameAlias$ref;
+    readonly " $refType": "TypenameAlias$ref";
 } | {
     readonly _typeAlias: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameAlias$ref;
+    readonly " $refType": "TypenameAlias$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly _typeAlias: "%other";
-    readonly " $refType": TypenameAlias$ref;
+    readonly " $refType": "TypenameAlias$ref";
 };
 
 
 // TypenameAliases.graphql
-export type TypenameAliases$ref = any;
 export type TypenameAliases = {
     readonly _typeAlias1: "User";
     readonly _typeAlias2: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameAliases$ref;
+    readonly " $refType": "TypenameAliases$ref";
 } | {
     readonly _typeAlias1: "Page";
     readonly _typeAlias2: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameAliases$ref;
+    readonly " $refType": "TypenameAliases$ref";
 } | {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
@@ -3711,7 +3587,7 @@ export type TypenameAliases = {
     /*This will never be '%other', but we need some
     value in case none of the concrete values match.*/
     readonly _typeAlias2: "%other";
-    readonly " $refType": TypenameAliases$ref;
+    readonly " $refType": "TypenameAliases$ref";
 };
 
 `;
@@ -3747,30 +3623,26 @@ fragment AnotherRecursiveFragment on Image {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 // UserProfile.graphql
-type PhotoFragment$ref = any;
-export type UserProfile$ref = any;
 export type UserProfile = {
     readonly profilePicture: {
         readonly uri: string | null;
         readonly width: number | null;
         readonly height: number | null;
-        readonly " $fragmentRefs": PhotoFragment$ref;
+        readonly " $fragmentRefs": FragmentRefs<"PhotoFragment">;
     } | null;
-    readonly " $refType": UserProfile$ref;
+    readonly " $refType": "UserProfile$ref";
 };
 
 
 // PhotoFragment.graphql
-export type PhotoFragment$ref = any;
 export type PhotoFragment = {
     readonly uri: string | null;
     readonly width: number | null;
-    readonly " $refType": PhotoFragment$ref;
+    readonly " $refType": "PhotoFragment$ref";
 };
 
 
 // RecursiveFragment.graphql
-export type RecursiveFragment$ref = any;
 export type RecursiveFragment = {
     readonly uri: string | null;
     readonly width: number | null;
@@ -3778,11 +3650,10 @@ export type RecursiveFragment = {
 
 
 // AnotherRecursiveFragment.graphql
-export type AnotherRecursiveFragment$ref = any;
 export type AnotherRecursiveFragment = {
     readonly uri: string | null;
     readonly height: number | null;
-    readonly " $refType": AnotherRecursiveFragment$ref;
+    readonly " $refType": "AnotherRecursiveFragment$ref";
 };
 
 `;


### PR DESCRIPTION
This PR fixes issue #138. 

Quick recap:

In TS 3.6 our 'opaque types' became unsafe as a result of refinement in the logic around how certain types intersect.

This PR works around that by combing types in a different way. Please refer to #138 for a discussion of the approach and rationale.

Note that by using string literals instead of unique symbols we gain improved DX in the form of more readable type errors. By switching the `" $refType"` property to use string literals we also simplify the implementation by avoiding the need to manage type imports.
