### PR TITLE
Add the ability to configure auto deploys

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,5 @@
 if [ ! -z "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
-  npx auto shipit
+  npx auto shipit $AUTO_OPTS
 else
   echo "Not on master, skipping deploy"
 fi


### PR DESCRIPTION
This adds the ability to configure the package publishing step via environment variables in travis. 

I've added `--dry-run` and `--verbose` flags via Travis' interface to temporarily disable the publishing step until we can dig into what's going wrong for auto

<img width="978" alt="image" src="https://user-images.githubusercontent.com/3087225/66578837-d0384780-eb49-11e9-9623-f3392ee7f4e0.png">
