### PR TITLE
Ensure tags are fetched for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_deploy:
   - git config --local user.email "${GIT_EMAIL}"
   - git remote rm origin
   - git remote add origin https://${GH_USER}:${GH_TOKEN}@github.com/relay-tools/relay-compiler-language-typescript.git
+  - git fetch origin --tags
   - git checkout master && git pull origin master
   - git branch --set-upstream-to origin/master master
   - yarn build


### PR DESCRIPTION
According to [this comment](https://github.com/intuit/auto/issues/624#issuecomment-544676295) our [previous failure](https://travis-ci.org/relay-tools/relay-compiler-language-typescript/builds/600835375?utm_source=github_status&utm_medium=notification) might be fixed by fetching the tags first. 

I won't force a release for this one, but once it goes through it'll be good to see if the release finishes without errors. It _should_ theoretically. 