### PR TITLE
Support relay-compiler --validate

### DIFF
--- a/src/formatGeneratedModule.ts
+++ b/src/formatGeneratedModule.ts
@@ -23,7 +23,7 @@ export const formatterFactory = (
     nodeStatement = addAnyTypeCast(nodeStatement).trim();
   }
   return `/* tslint:disable */
-
+${hash ? `/* ${hash} */\n` : ""}
 ${documentTypeImport}
 ${typeText || ""}
 

--- a/test/fixtures/generated-module/complete-example.ts
+++ b/test/fixtures/generated-module/complete-example.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* @relayHash abcde */
 
 import { ConcreteFragment } from "relay-runtime";
 export type CompleteExample = { readonly id: string }

--- a/test/formatGeneratedModule-test.ts
+++ b/test/formatGeneratedModule-test.ts
@@ -45,7 +45,7 @@ describe("formatGeneratedModule", () => {
         docText: null,
         concreteText: JSON.stringify({ the: { fragment: { data: 42 } } }),
         typeText: "export type CompleteExample = { readonly id: string }",
-        hash: "abcde",
+        hash: "@relayHash abcde",
         relayRuntimeModule: "relay-runtime",
         sourceHash: "edcba"
       })
@@ -63,7 +63,7 @@ describe("formatGeneratedModule", () => {
         docText: null,
         concreteText: JSON.stringify({ the: { fragment: { data: 42 } } }),
         typeText: "export type CompleteExample = { readonly id: string }",
-        hash: "abcde",
+        hash: "@relayHash abcde",
         sourceHash: "edcba"
       })
     ).toMatchFile(
@@ -80,7 +80,7 @@ describe("formatGeneratedModule", () => {
         docText: null,
         concreteText: JSON.stringify({ the: { fragment: { data: 42 } } }),
         typeText: "export type CompleteExample = { readonly id: string }",
-        hash: "abcde",
+        hash: null,
         sourceHash: "edcba"
       })
     ).toMatchFile(


### PR DESCRIPTION
The Flow language plugin emits a special [@relayHash pragma comment](https://github.com/relayjs/relay-examples/blob/205dfb195c770e7cd3977116654bd69c91d03b90/todo/__generated__/relay/AddTodoMutation.graphql.js#L3) that is [generated](https://github.com/facebook/relay/blob/597d2a17aa29d401830407b6814a5f8d148f632d/packages/relay-compiler/codegen/writeRelayGeneratedFile.js#L180) by the Relay compiler and is [utilized](https://github.com/facebook/relay/blob/597d2a17aa29d401830407b6814a5f8d148f632d/packages/relay-compiler/codegen/writeRelayGeneratedFile.js#L214) when running the compiler with the `--validate` flag.

This change adds the same code comment to the emitted TypeScript artifacts. 

Fixes #98.