### PR TITLE
feat: Disable eslint for generated modules

### DIFF
--- a/src/formatGeneratedModule.ts
+++ b/src/formatGeneratedModule.ts
@@ -23,6 +23,7 @@ export const formatterFactory = (
     nodeStatement = addAnyTypeCast(nodeStatement).trim();
   }
   return `/* tslint:disable */
+/* eslint-disable */
 ${hash ? `/* ${hash} */\n` : ""}
 ${documentTypeImport}
 ${typeText || ""}

--- a/test/fixtures/generated-module/complete-example-no-cast.ts
+++ b/test/fixtures/generated-module/complete-example-no-cast.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 
 import { ConcreteFragment } from "relay-runtime";
 export type CompleteExample = { readonly id: string }

--- a/test/fixtures/generated-module/complete-example.ts
+++ b/test/fixtures/generated-module/complete-example.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 /* @relayHash abcde */
 
 import { ConcreteFragment } from "relay-runtime";


### PR DESCRIPTION
tsling is slowly going to start deprecating itself in favour of integrating with eslint. So I dare say our consumers are slowly going to start adopting this. I know I have already moved there.

https://medium.com/palantir/tslint-in-2019-1a144c2317a9