### PR TITLE
Specify the version of auto or default to v7

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,5 @@
 if [ ! -z "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
-  npx auto shipit $AUTO_OPTS
+  npx auto@$AUTO_VERSION shipit $AUTO_OPTS
 else
   echo "Not on master, skipping deploy"
 fi


### PR DESCRIPTION
Fixes #167. 

There was a breaking change deployed in [auto](https://github.com/intuit/auto) and  the deploy script was automatically upgrading to the latest version. 

I'll be updating the config next week so I'll update the version then. I've set `$AUTO_VERSION` in circle to be `v7.6.0` which is what Artsy is running at the moment. 