### PR TITLE
Correct example installing steps

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -9,12 +9,15 @@ yarn global add yalc
 And in the project root folder
 
 ```
+yarn install
 yarn watch
 ```
 
 ## Installation
+In the example folder link development version to example and install
 
 ```
+yalc add relay-compiler-language-typescript
 yarn install
 ```
 


### PR DESCRIPTION
There was no where in the readme that stated you needed to `yalc add relay-compiler-language-typescript` which if you've never used yalc is was confusing.