### PR TITLE
fix(TypeScriptGenerator): omit FragmentReference from refetchable query

### DIFF
--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -3,7 +3,6 @@ import {
   Fragment,
   IRVisitor,
   LinkedField,
-  Metadata,
   Root,
   ScalarField,
   Schema,
@@ -468,13 +467,6 @@ function createVisitor(
             normalizationIR,
             createRawResponseTypeVisitor(schema, state)
           );
-        }
-        const refetchableFragmentName = getRefetchableQueryParentFragmentName(
-          state,
-          node.metadata
-        );
-        if (refetchableFragmentName !== null) {
-          state.runtimeImports.add("FragmentReference");
         }
         const nodes = [];
         if (state.runtimeImports.size) {
@@ -1077,25 +1069,6 @@ function getEnumDefinitions(
       )
     );
   });
-}
-
-// If it's a @refetchable fragment, we generate the $fragmentRef in generated
-// query, and import it in the fragment to avoid circular dependencies
-function getRefetchableQueryParentFragmentName(
-  state: State,
-  metadata: Metadata
-): string | null {
-  if (
-    (metadata && !metadata.isRefetchableQuery) ||
-    (!state.useHaste && !state.useSingleArtifactDirectory)
-  ) {
-    return null;
-  }
-  const derivedFrom = metadata && metadata.derivedFrom;
-  if (derivedFrom !== null && typeof derivedFrom === "string") {
-    return derivedFrom;
-  }
-  return null;
 }
 
 function stringLiteralTypeAnnotation(name: string): ts.TypeNode {

--- a/test/__snapshots__/TypeScriptGenerator-test.ts.snap
+++ b/test/__snapshots__/TypeScriptGenerator-test.ts.snap
@@ -1620,7 +1620,7 @@ export type RefetchableFragment$key = {
 
 
 // RefetchableFragmentQuery.graphql
-import { FragmentReference, FragmentRefs } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
 export type RefetchableFragmentQueryVariables = {
     id: string;
 };


### PR DESCRIPTION
Closes: #182 

There are no circular dependency issues in the TS generator because it does not actually import the fragment, instead it references it using the `FragmentRefs` generic. [In comparison to how the Flow generator works](https://github.com/facebook/relay/blob/3457604b90ac160a164b9945ca6c23f0ab313fc1/packages/relay-compiler/language/javascript/RelayFlowGenerator.js#L988-L1004).

This means that generating the fragment **in** the query of a `@refetchable` is unnecessary.