### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ TypeScript support, including emitting type definitions.
 Add the package to your dev dependencies:
 
 ```
-yarn add graphql graphql-compiler --dev
+yarn add graphql relay-compiler --dev
 yarn add typescript relay-compiler-language-typescript --dev
 ```
 


### PR DESCRIPTION
I think this is a typo in the installation instructions (```graphql-compiler``` is [this package](https://github.com/kensho-technologies/graphql-compiler) whereas I think it is supposed to link to ```relay-compiler```).