### PR TITLE
Improve type generation accuracy

### DIFF
--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -215,10 +215,19 @@ function selectionsToAST(
     const typenameAliases = new Set<string>();
 
     for (const concreteType in byConcreteType) {
+      const concreteTypeSelections = byConcreteType[concreteType];
+      const concreteTypeSelectionsNames = concreteTypeSelections.map(
+        selection => selection.schemaName
+      );
+
       types.push(
         groupRefs([
-          ...Array.from(baseFields.values()),
-          ...byConcreteType[concreteType]
+          // Deduplicate any fields also selected on the concrete type.
+          ...Array.from(baseFields.values()).filter(
+            selection =>
+              !concreteTypeSelectionsNames.includes(selection.schemaName)
+          ),
+          ...concreteTypeSelections
         ]).map(selection => {
           if (selection.schemaName === "__typename") {
             typenameAliases.add(selection.key);

--- a/test/__snapshots__/TypeScriptGenerator-test.ts.snap
+++ b/test/__snapshots__/TypeScriptGenerator-test.ts.snap
@@ -446,9 +446,7 @@ export type UnionTypeTestResponse = {
         readonly __typename: "FakeNode";
         readonly id: string;
     } | {
-        /*This will never be '%other', but we need some
-        value in case none of the concrete values match.*/
-        readonly __typename: "%other";
+        readonly __typename: "NonNode";
     }) | null;
 };
 export type UnionTypeTest = {
@@ -1684,7 +1682,7 @@ export type RelayClientIDFieldQueryResponse = {
         readonly id: string;
         readonly commentBody?: {
             readonly __id: string;
-            readonly __typename: string;
+            readonly __typename: "PlainCommentBody" | "MarkdownCommentBody";
             readonly text?: {
                 readonly __id: string;
                 readonly __typename: string;
@@ -2680,9 +2678,7 @@ export type UnionTypeTestResponse = {
         readonly __typename: "FakeNode";
         readonly id: string;
     } | {
-        /*This will never be '%other', but we need some
-        value in case none of the concrete values match.*/
-        readonly __typename: "%other";
+        readonly __typename: "NonNode";
     }) | null;
 };
 export type UnionTypeTest = {
@@ -3918,7 +3914,7 @@ export type RelayClientIDFieldQueryResponse = {
         readonly id: string;
         readonly commentBody?: {
             readonly __id: string;
-            readonly __typename: string;
+            readonly __typename: "PlainCommentBody" | "MarkdownCommentBody";
             readonly text?: {
                 readonly __id: string;
                 readonly __typename: string;


### PR DESCRIPTION
Look at the commits for more details. Basically I have included some changes to support more accurate type output, especially regarding union types and type names.

Fixes #190, and maybe #186.