### PR TITLE
Disable ts-checks on output files

### DIFF
--- a/src/formatGeneratedModule.ts
+++ b/src/formatGeneratedModule.ts
@@ -24,6 +24,7 @@ export const formatterFactory = (
   }
   return `/* tslint:disable */
 /* eslint-disable */
+// @ts-nocheck
 ${hash ? `/* ${hash} */\n` : ""}
 ${documentTypeImport}
 ${typeText || ""}

--- a/test/fixtures/generated-module/complete-example-no-cast.ts
+++ b/test/fixtures/generated-module/complete-example-no-cast.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @ts-nocheck
 
 import { ConcreteFragment } from "relay-runtime";
 export type CompleteExample = { readonly id: string }

--- a/test/fixtures/generated-module/complete-example.ts
+++ b/test/fixtures/generated-module/complete-example.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @ts-nocheck
 /* @relayHash abcde */
 
 import { ConcreteFragment } from "relay-runtime";


### PR DESCRIPTION
This would disable ts checking on the whole file for all output files to enable usage of `"importsNotUsedAsValues": "error"`. If needed I could spend some more time to make the change only target the imports, but since both tslint and eslint are disabled for the whole file I figured this could be an acceptable solution.

Fixes #177