### PR TITLE
fix: bring package in a state where build and test do not fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  push:
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache node_modules
+        id: cache-modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('yarn.lock') }}
+      - run: yarn install
+      - run: yarn test
+      - run: yarn build
+      - run: yarn lint

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc",
+    "build": "rm -rf lib && tsc --project tsconfig.build.json",
     "lint": "tslint -c tslint.json --project tsconfig.json",
     "pr-check": "scripts/pr-check.sh",
     "prettier": "prettier --write '{src,types,test}/**/*.ts'",
@@ -41,7 +41,7 @@
     "sync-fixtures": "ts-node ./syncFixtures.ts",
     "test": "npm run type-check && jest",
     "type-check": "tsc --noEmit --pretty",
-    "watch": "concurrently 'tsc --watch' 'chokidar \"lib/**/*.js\" -c \"yalc publish --force --push\"'"
+    "watch": "concurrently 'tsc --watch --project tsconfig.build.json' 'chokidar \"lib/**/*.js\" -c \"yalc publish --force --push\"'"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@artsy/auto-config": "^1.0.0",
+    "@babel/runtime": "7.12.13",
     "@types/graphql": "^14.2.3",
     "@types/invariant": "2.2.34",
     "@types/jest": "^26.0.20",

--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -7,7 +7,7 @@ import {
   ScalarField,
   Schema,
   TypeGenerator,
-  TypeID
+  TypeID,
 } from "relay-compiler";
 import { TypeGeneratorOptions } from "relay-compiler/lib/language/RelayLanguagePluginInterface";
 import * as FlattenTransform from "relay-compiler/lib/transforms/FlattenTransform";
@@ -19,7 +19,7 @@ import * as ts from "typescript";
 import {
   State,
   transformInputType,
-  transformScalarType
+  transformScalarType,
 } from "./TypeScriptTypeTransformers";
 
 type Selection = {
@@ -64,28 +64,28 @@ export const generate: TypeGenerator["generate"] = (schema, node, options) => {
 };
 
 function aggregateRuntimeImports(ast: ts.Statement[]) {
-  const importNodes = ast.filter(declaration =>
+  const importNodes = ast.filter((declaration) =>
     ts.isImportDeclaration(declaration)
   ) as ts.ImportDeclaration[];
 
   const runtimeImports = importNodes.filter(
-    importDeclaration =>
+    (importDeclaration) =>
       (importDeclaration.moduleSpecifier as ts.StringLiteral).text ===
       "relay-runtime"
   );
 
   if (runtimeImports.length > 1) {
     const namedImports: string[] = [];
-    runtimeImports.map(node => {
+    runtimeImports.map((node) => {
       (node.importClause!.namedBindings! as ts.NamedImports).elements.map(
-        element => {
+        (element) => {
           namedImports.push(element.name.text);
         }
       );
     });
 
     const importSpecifiers: ts.ImportSpecifier[] = [];
-    namedImports.map(namedImport => {
+    namedImports.map((namedImport) => {
       const specifier = ts.createImportSpecifier(
         undefined,
         ts.createIdentifier(namedImport)
@@ -150,6 +150,7 @@ function makeProp(
   }
   const typeProperty = objectTypeProperty(key, value);
   if (conditional) {
+    // @ts-ignore
     typeProperty.questionToken = ts.createToken(ts.SyntaxKind.QuestionToken);
   }
 
@@ -176,7 +177,7 @@ function selectionsToAST(
 
   const byConcreteType: { [type: string]: Selection[] } = {};
 
-  flattenArray(selections).forEach(selection => {
+  flattenArray(selections).forEach((selection) => {
     const { concreteType } = selection;
 
     if (concreteType) {
@@ -198,7 +199,7 @@ function selectionsToAST(
     Object.keys(byConcreteType).length > 0 &&
     onlySelectsTypename(Array.from(baseFields.values())) &&
     (hasTypenameSelection(Array.from(baseFields.values())) ||
-      Object.keys(byConcreteType).every(type =>
+      Object.keys(byConcreteType).every((type) =>
         hasTypenameSelection(byConcreteType[type])
       ))
   ) {
@@ -208,8 +209,8 @@ function selectionsToAST(
       types.push(
         groupRefs([
           ...Array.from(baseFields.values()),
-          ...byConcreteType[concreteType]
-        ]).map(selection => {
+          ...byConcreteType[concreteType],
+        ]).map((selection) => {
           if (selection.schemaName === "__typename") {
             typenameAliases.add(selection.key);
           }
@@ -222,7 +223,7 @@ function selectionsToAST(
     // would set the type to diff(string, set of listed concrete types), but
     // this doesn't exist in Flow at the time.
     types.push(
-      Array.from(typenameAliases).map(typenameAlias => {
+      Array.from(typenameAliases).map((typenameAlias) => {
         const otherProp = objectTypeProperty(
           typenameAlias,
           ts.createLiteralTypeNode(ts.createLiteral("%other"))
@@ -246,22 +247,22 @@ function selectionsToAST(
       selectionMap = mergeSelections(
         selectionMap,
         selectionsToMap(
-          byConcreteType[concreteType].map(sel => ({
+          byConcreteType[concreteType].map((sel) => ({
             ...sel,
-            conditional: true
+            conditional: true,
           }))
         )
       );
     }
 
     const selectionMapValues = groupRefs(Array.from(selectionMap.values())).map(
-      sel =>
+      (sel) =>
         isTypenameSelection(sel) && sel.concreteType
           ? makeProp(
               schema,
               {
                 ...sel,
-                conditional: false
+                conditional: false,
               },
               state,
               unmasked,
@@ -273,7 +274,7 @@ function selectionsToAST(
     types.push(selectionMapValues);
   }
 
-  const typeElements = types.map(props => {
+  const typeElements = types.map((props) => {
     if (fragmentTypeName) {
       props.push(
         objectTypeProperty(
@@ -334,7 +335,7 @@ function mergeSelection(
     if (shouldSetConditional) {
       return {
         ...b,
-        conditional: true
+        conditional: true,
       };
     }
 
@@ -350,7 +351,7 @@ function mergeSelection(
           shouldSetConditional
         )
       : null,
-    conditional: a.conditional && b.conditional
+    conditional: a.conditional && b.conditional,
   };
 }
 
@@ -395,7 +396,7 @@ function importTypes(names: string[], fromModule: string): ts.Statement {
       ts.createImportClause(
         undefined,
         ts.createNamedImports(
-          names.map(name =>
+          names.map((name) =>
             ts.createImportSpecifier(undefined, ts.createIdentifier(name))
           )
         )
@@ -422,7 +423,7 @@ function createVisitor(
     useSingleArtifactDirectory: options.useSingleArtifactDirectory,
     noFutureProofEnums: options.noFutureProofEnums,
     matchFields: new Map(),
-    runtimeImports: new Set()
+    runtimeImports: new Set(),
   };
 
   return {
@@ -453,7 +454,7 @@ function createVisitor(
           objectTypeProperty(
             "variables",
             ts.createTypeReferenceNode(inputVariablesType.name, undefined)
-          )
+          ),
         ];
 
         // Generate raw response type
@@ -461,7 +462,7 @@ function createVisitor(
         const { normalizationIR } = options;
         if (
           normalizationIR &&
-          node.directives.some(d => d.name === DIRECTIVE_NAME)
+          node.directives.some((d) => d.name === DIRECTIVE_NAME)
         ) {
           rawResponseType = IRVisitor.visit(
             normalizationIR,
@@ -510,9 +511,9 @@ function createVisitor(
           (node.selections as any) as ReadonlyArray<ReadonlyArray<Selection>>
         );
         const numConcreteSelections = flattenedSelections.filter(
-          s => s.concreteType
+          (s) => s.concreteType
         ).length;
-        const selections = flattenedSelections.map(selection => {
+        const selections = flattenedSelections.map((selection) => {
           if (
             numConcreteSelections <= 1 &&
             isTypenameSelection(selection) &&
@@ -521,8 +522,8 @@ function createVisitor(
             return [
               {
                 ...selection,
-                concreteType: schema.getTypeString(node.type)
-              }
+                concreteType: schema.getTypeString(node.type),
+              },
             ];
           }
           return [selection];
@@ -538,19 +539,20 @@ function createVisitor(
           ts.createTypeReferenceNode(dataTypeName, undefined),
           { optional: true }
         );
+        // @ts-ignore
         refTypeDataProperty.questionToken = ts.createToken(
           ts.SyntaxKind.QuestionToken
         );
         const refTypeFragmentRefProperty = objectTypeProperty(
           FRAGMENT_REFS,
           ts.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [
-            ts.createLiteralTypeNode(ts.createStringLiteral(node.name))
+            ts.createLiteralTypeNode(ts.createStringLiteral(node.name)),
           ])
         );
         const isPluralFragment = isPlural(node);
         const refType = exactObjectTypeAnnotation([
           refTypeDataProperty,
-          refTypeFragmentRefProperty
+          refTypeFragmentRefProperty,
         ]);
 
         const unmasked = node.metadata != null && node.metadata.mask === false;
@@ -563,7 +565,7 @@ function createVisitor(
         );
         const type = isPlural(node)
           ? ts.createTypeReferenceNode(ts.createIdentifier("ReadonlyArray"), [
-              baseType
+              baseType,
             ])
           : baseType;
         state.runtimeImports.add("FragmentRefs");
@@ -581,22 +583,22 @@ function createVisitor(
                   [refType]
                 )
               : refType
-          )
+          ),
         ];
       },
       InlineFragment(node) {
         return flattenArray(
           /* $FlowFixMe: selections have already been transformed */
           (node.selections as any) as ReadonlyArray<ReadonlyArray<Selection>>
-        ).map(typeSelection => {
+        ).map((typeSelection) => {
           return schema.isAbstractType(node.typeCondition)
             ? {
                 ...typeSelection,
-                conditional: true
+                conditional: true,
               }
             : {
                 ...typeSelection,
-                concreteType: schema.getTypeString(node.typeCondition)
+                concreteType: schema.getTypeString(node.typeCondition),
               };
         });
       },
@@ -604,10 +606,10 @@ function createVisitor(
         return flattenArray(
           /* $FlowFixMe: selections have already been transformed */
           (node.selections as any) as ReadonlyArray<ReadonlyArray<Selection>>
-        ).map(selection => {
+        ).map((selection) => {
           return {
             ...selection,
-            conditional: true
+            conditional: true,
           };
         });
       },
@@ -621,17 +623,25 @@ function createVisitor(
           {
             key: "__fragmentPropName",
             conditional: true,
-            value: transformScalarType(schema, schema.expectStringType(), state)
+            value: transformScalarType(
+              schema,
+              schema.expectStringType(),
+              state
+            ),
           },
           {
             key: "__module_component",
             conditional: true,
-            value: transformScalarType(schema, schema.expectStringType(), state)
+            value: transformScalarType(
+              schema,
+              schema.expectStringType(),
+              state
+            ),
           },
           {
             key: "__fragments_" + node.name,
-            ref: node.name
-          }
+            ref: node.name,
+          },
         ];
       },
       FragmentSpread(node) {
@@ -639,11 +649,11 @@ function createVisitor(
         return [
           {
             key: "__fragments_" + node.name,
-            ref: node.name
-          }
+            ref: node.name,
+          },
         ];
-      }
-    }
+      },
+    },
   };
 }
 
@@ -652,8 +662,8 @@ function visitScalarField(schema: Schema, node: ScalarField, state: State) {
     {
       key: node.alias || node.name,
       schemaName: node.name,
-      value: transformScalarType(schema, node.type, state)
-    }
+      value: transformScalarType(schema, node.type, state),
+    },
   ];
 }
 
@@ -673,8 +683,8 @@ function visitLinkedField(node: LinkedField) {
          * concreteTypes don't get overwritten by each other
          */
         true
-      )
-    }
+      ),
+    },
   ];
 }
 
@@ -687,7 +697,7 @@ function makeRawResponseProp(
     conditional,
     nodeType,
     nodeSelections,
-    kind
+    kind,
   }: Selection,
   state: State,
   concreteType?: string | null
@@ -719,6 +729,7 @@ function makeRawResponseProp(
 
   const typeProperty = objectTypeProperty(key, value);
   if (conditional) {
+    // @ts-ignore
     typeProperty.questionToken = ts.createToken(ts.SyntaxKind.QuestionToken);
   }
 
@@ -731,7 +742,7 @@ function selectionsToMap(
 ): SelectionMap {
   const map = new Map();
 
-  selections.forEach(selection => {
+  selections.forEach((selection) => {
     const key =
       appendType && selection.concreteType
         ? `${selection.key}::${selection.concreteType}`
@@ -758,7 +769,7 @@ function selectionsToRawResponseBabel(
   const baseFields: any[] = [];
   const byConcreteType: Record<string, any> = {};
 
-  flattenArray(selections).forEach(selection => {
+  flattenArray(selections).forEach((selection) => {
     const { concreteType } = selection;
 
     if (concreteType) {
@@ -783,7 +794,7 @@ function selectionsToRawResponseBabel(
       );
       types.push(
         exactObjectTypeAnnotation(
-          mergedSeletions.map(selection =>
+          mergedSeletions.map((selection) =>
             makeRawResponseProp(schema, selection, state, concreteType)
           )
         )
@@ -794,7 +805,7 @@ function selectionsToRawResponseBabel(
   if (baseFields.length > 0) {
     types.push(
       exactObjectTypeAnnotation(
-        baseFields.map(selection =>
+        baseFields.map((selection) =>
           makeRawResponseProp(schema, selection, state, nodeTypeName)
         )
       )
@@ -811,7 +822,7 @@ function appendLocal3DPayload(
   state: State,
   currentType?: string | null
 ): void {
-  const moduleImport = selections.find(sel => sel.kind === "ModuleImport");
+  const moduleImport = selections.find((sel) => sel.kind === "ModuleImport");
   if (moduleImport) {
     // Generate an extra opaque type for client 3D fields
     state.runtimeImports.add("Local3DPayload");
@@ -820,11 +831,11 @@ function appendLocal3DPayload(
         stringLiteralTypeAnnotation(moduleImport.documentName!),
         exactObjectTypeAnnotation(
           selections
-            .filter(sel => sel.schemaName !== "js")
-            .map(selection =>
+            .filter((sel) => sel.schemaName !== "js")
+            .map((selection) =>
               makeRawResponseProp(schema, selection, state, currentType)
             )
-        )
+        ),
       ])
     );
   }
@@ -855,12 +866,12 @@ function createRawResponseTypeVisitor(
         return flattenArray(
           /* $FlowFixMe: selections have already been transformed */
           (node.selections as any) as ReadonlyArray<ReadonlyArray<Selection>>
-        ).map(typeSelection => {
+        ).map((typeSelection) => {
           return schema.isAbstractType(typeCondition)
             ? typeSelection
             : {
                 ...typeSelection,
-                concreteType: schema.getTypeString(typeCondition)
+                concreteType: schema.getTypeString(typeCondition),
               };
         });
       },
@@ -871,9 +882,9 @@ function createRawResponseTypeVisitor(
         return flattenArray(
           /* $FlowFixMe: selections have already been transformed */
           (node.selections as any) as ReadonlyArray<ReadonlyArray<Selection>>
-        ).map(sel => ({
+        ).map((sel) => ({
           ...sel,
-          conditional: true
+          conditional: true,
         }));
       },
       LinkedField: visitLinkedField,
@@ -903,8 +914,8 @@ function createRawResponseTypeVisitor(
           "A fragment spread is found when traversing the AST, " +
             "make sure you are passing the codegen IR"
         );
-      }
-    }
+      },
+    },
   };
 }
 
@@ -938,8 +949,8 @@ function visitRawResponseModuleImport(
     {
       key,
       kind: "ModuleImport",
-      documentName: node.documentName
-    }
+      documentName: node.documentName,
+    },
   ];
 }
 
@@ -948,13 +959,13 @@ function flattenArray(
 ): Selection[] {
   const result: Selection[] = [];
 
-  arrayOfArrays.forEach(array => result.push(...array));
+  arrayOfArrays.forEach((array) => result.push(...array));
 
   return result;
 }
 
 function generateInputObjectTypes(state: State) {
-  return Object.keys(state.generatedInputObjectTypes).map(typeIdentifier => {
+  return Object.keys(state.generatedInputObjectTypes).map((typeIdentifier) => {
     const inputObjectType = state.generatedInputObjectTypes[typeIdentifier];
 
     if (inputObjectType === "pending") {
@@ -972,7 +983,7 @@ function generateInputVariablesType(schema: Schema, node: Root, state: State) {
   return exportType(
     `${node.name}Variables`,
     exactObjectTypeAnnotation(
-      node.argumentDefinitions.map(arg => {
+      node.argumentDefinitions.map((arg) => {
         return objectTypeProperty(
           arg.name,
           transformInputType(schema, arg.type, state),
@@ -988,7 +999,7 @@ function groupRefs(props: Selection[]): Selection[] {
 
   const refs: string[] = [];
 
-  props.forEach(prop => {
+  props.forEach((prop) => {
     if (prop.ref) {
       refs.push(prop.ref);
     } else {
@@ -998,13 +1009,13 @@ function groupRefs(props: Selection[]): Selection[] {
 
   if (refs.length > 0) {
     const refTypes = ts.createUnionTypeNode(
-      refs.map(ref => ts.createLiteralTypeNode(ts.createStringLiteral(ref)))
+      refs.map((ref) => ts.createLiteralTypeNode(ts.createStringLiteral(ref)))
     );
 
     result.push({
       key: FRAGMENT_REFS,
       conditional: false,
-      value: ts.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [refTypes])
+      value: ts.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [refTypes]),
     });
   }
 
@@ -1023,11 +1034,11 @@ function getFragmentRefsTypeImport(state: State): ts.Statement[] {
             ts.createImportSpecifier(
               undefined,
               ts.createIdentifier("FragmentRefs")
-            )
+            ),
           ])
         ),
         ts.createStringLiteral("relay-runtime")
-      )
+      ),
     ];
   }
 
@@ -1049,12 +1060,12 @@ function getEnumDefinitions(
   }
 
   if (typeof enumsHasteModule === "function") {
-    return enumNames.map(enumName =>
+    return enumNames.map((enumName) =>
       importTypes([enumName], enumsHasteModule(enumName))
     );
   }
 
-  return enumNames.map(name => {
+  return enumNames.map((name) => {
     const values = [...schema.getEnumValues(usedEnums[name])];
     values.sort();
 
@@ -1065,7 +1076,7 @@ function getEnumDefinitions(
     return exportType(
       name,
       ts.createUnionTypeNode(
-        values.map(value => stringLiteralTypeAnnotation(value))
+        values.map((value) => stringLiteralTypeAnnotation(value))
       )
     );
   });
@@ -1090,5 +1101,5 @@ export const transforms: TypeGenerator["transforms"] = [
   MaskTransform.transform,
   MatchTransform.transform,
   FlattenTransform.transformWithOptions({}),
-  RefetchableFragmentTransform.transform
+  RefetchableFragmentTransform.transform,
 ];

--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -51,14 +51,14 @@ export const generate: TypeGenerator["generate"] = (schema, node, options) => {
   const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 
   const resultFile = ts.createSourceFile(
-    "grapghql-def.ts",
+    "graphql-def.ts",
     "",
     ts.ScriptTarget.Latest,
     false,
     ts.ScriptKind.TS
   );
 
-  const fullProgramAst = ts.updateSourceFileNode(resultFile, ast);
+  const fullProgramAst = ts.factory.updateSourceFile(resultFile, ast);
 
   return printer.printNode(ts.EmitHint.SourceFile, fullProgramAst, resultFile);
 };
@@ -86,9 +86,9 @@ function aggregateRuntimeImports(ast: ts.Statement[]) {
 
     const importSpecifiers: ts.ImportSpecifier[] = [];
     namedImports.map((namedImport) => {
-      const specifier = ts.createImportSpecifier(
+      const specifier = ts.factory.createImportSpecifier(
         undefined,
-        ts.createIdentifier(namedImport)
+        ts.factory.createIdentifier(namedImport)
       );
       importSpecifiers.push(specifier);
     });
@@ -97,8 +97,8 @@ function aggregateRuntimeImports(ast: ts.Statement[]) {
     const aggregatedRuntimeImportDeclaration = ts.createImportDeclaration(
       undefined,
       undefined,
-      ts.createImportClause(undefined, namedBindings),
-      ts.createStringLiteral("relay-runtime")
+      ts.factory.createImportClause(false, undefined, namedBindings),
+      ts.factory.createStringLiteral("relay-runtime")
     );
 
     const aggregatedRuntimeImportAST = ast.reduce<ts.Statement[]>(
@@ -115,7 +115,7 @@ function aggregateRuntimeImports(ast: ts.Statement[]) {
   }
 }
 
-function nullthrows<T>(obj: T | null | undefined): T {
+function nullThrows<T>(obj: T | null | undefined): T {
   if (obj == null) {
     throw new Error("Obj is null");
   }
@@ -134,7 +134,9 @@ function makeProp(
   const { key, schemaName, conditional, nodeType, nodeSelections } = selection;
 
   if (schemaName === "__typename" && concreteType) {
-    value = ts.createLiteralTypeNode(ts.createLiteral(concreteType));
+    value = ts.factory.createLiteralTypeNode(
+      ts.factory.createStringLiteral(concreteType)
+    );
   } else if (nodeType) {
     value = transformScalarType(
       schema,
@@ -142,7 +144,7 @@ function makeProp(
       state,
       selectionsToAST(
         schema,
-        [Array.from(nullthrows(nodeSelections).values())],
+        [Array.from(nullThrows(nodeSelections).values())],
         state,
         unmasked
       )
@@ -151,7 +153,9 @@ function makeProp(
   const typeProperty = objectTypeProperty(key, value);
   if (conditional) {
     // @ts-ignore
-    typeProperty.questionToken = ts.createToken(ts.SyntaxKind.QuestionToken);
+    typeProperty.questionToken = ts.factory.createToken(
+      ts.SyntaxKind.QuestionToken
+    );
   }
 
   return typeProperty;
@@ -226,7 +230,9 @@ function selectionsToAST(
       Array.from(typenameAliases).map((typenameAlias) => {
         const otherProp = objectTypeProperty(
           typenameAlias,
-          ts.createLiteralTypeNode(ts.createLiteral("%other"))
+          ts.factory.createLiteralTypeNode(
+            ts.factory.createStringLiteral("%other")
+          )
         );
 
         const otherPropWithComment = ts.addSyntheticLeadingComment(
@@ -279,13 +285,15 @@ function selectionsToAST(
       props.push(
         objectTypeProperty(
           REF_TYPE,
-          ts.createLiteralTypeNode(ts.createStringLiteral(fragmentTypeName))
+          ts.factory.createLiteralTypeNode(
+            ts.factory.createStringLiteral(fragmentTypeName)
+          )
         )
       );
     }
 
     return unmasked
-      ? ts.createTypeLiteralNode(props)
+      ? ts.factory.createTypeLiteralNode(props)
       : exactObjectTypeAnnotation(props);
   });
 
@@ -293,14 +301,14 @@ function selectionsToAST(
     return typeElements[0];
   }
 
-  return ts.createUnionTypeNode(typeElements);
+  return ts.factory.createUnionTypeNode(typeElements);
 }
 
 // We don't have exact object types in typescript.
 function exactObjectTypeAnnotation(
   properties: ts.PropertySignature[]
 ): ts.TypeLiteralNode {
-  return ts.createTypeLiteralNode(properties);
+  return ts.factory.createTypeLiteralNode(properties);
 }
 
 const idRegex = /^[$a-zA-Z_][$a-z0-9A-Z_]*$/;
@@ -312,17 +320,16 @@ function objectTypeProperty(
 ): ts.PropertySignature {
   const { optional, readonly = true } = options;
   const modifiers = readonly
-    ? [ts.createToken(ts.SyntaxKind.ReadonlyKeyword)]
+    ? [ts.factory.createToken(ts.SyntaxKind.ReadonlyKeyword)]
     : undefined;
 
-  return ts.createPropertySignature(
+  return ts.factory.createPropertySignature(
     modifiers,
     idRegex.test(propertyName)
-      ? ts.createIdentifier(propertyName)
-      : ts.createLiteral(propertyName),
-    optional ? ts.createToken(ts.SyntaxKind.QuestionToken) : undefined,
-    type,
-    undefined
+      ? ts.factory.createIdentifier(propertyName)
+      : ts.factory.createStringLiteral(propertyName),
+    optional ? ts.factory.createToken(ts.SyntaxKind.QuestionToken) : undefined,
+    type
   );
 }
 
@@ -347,7 +354,7 @@ function mergeSelection(
     nodeSelections: a.nodeSelections
       ? mergeSelections(
           a.nodeSelections,
-          nullthrows(b.nodeSelections),
+          nullThrows(b.nodeSelections),
           shouldSetConditional
         )
       : null,
@@ -378,10 +385,10 @@ function isPlural(node: Fragment): boolean {
 }
 
 function exportType(name: string, type: ts.TypeNode) {
-  return ts.createTypeAliasDeclaration(
+  return ts.factory.createTypeAliasDeclaration(
     undefined,
-    [ts.createToken(ts.SyntaxKind.ExportKeyword)],
-    ts.createIdentifier(name),
+    [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+    ts.factory.createIdentifier(name),
     undefined,
     type
   );
@@ -390,18 +397,22 @@ function exportType(name: string, type: ts.TypeNode) {
 function importTypes(names: string[], fromModule: string): ts.Statement {
   return (
     names &&
-    ts.createImportDeclaration(
+    ts.factory.createImportDeclaration(
       undefined,
       undefined,
-      ts.createImportClause(
+      ts.factory.createImportClause(
+        false,
         undefined,
-        ts.createNamedImports(
+        ts.factory.createNamedImports(
           names.map((name) =>
-            ts.createImportSpecifier(undefined, ts.createIdentifier(name))
+            ts.factory.createImportSpecifier(
+              undefined,
+              ts.factory.createIdentifier(name)
+            )
           )
         )
       ),
-      ts.createLiteral(fromModule)
+      ts.factory.createStringLiteral(fromModule)
     )
   );
 }
@@ -449,11 +460,14 @@ function createVisitor(
         const operationTypes = [
           objectTypeProperty(
             "response",
-            ts.createTypeReferenceNode(responseType.name, undefined)
+            ts.factory.createTypeReferenceNode(responseType.name, undefined)
           ),
           objectTypeProperty(
             "variables",
-            ts.createTypeReferenceNode(inputVariablesType.name, undefined)
+            ts.factory.createTypeReferenceNode(
+              inputVariablesType.name,
+              undefined
+            )
           ),
         ];
 
@@ -494,7 +508,10 @@ function createVisitor(
           operationTypes.push(
             objectTypeProperty(
               "rawResponse",
-              ts.createTypeReferenceNode(`${node.name}RawResponse`, undefined)
+              ts.factory.createTypeReferenceNode(
+                `${node.name}RawResponse`,
+                undefined
+              )
             )
           );
 
@@ -531,22 +548,27 @@ function createVisitor(
         state.generatedFragments.add(node.name);
 
         const dataTypeName = getDataTypeName(node.name);
-        const dataType = ts.createTypeReferenceNode(node.name, undefined);
+        const dataType = ts.factory.createTypeReferenceNode(
+          node.name,
+          undefined
+        );
 
         const refTypeName = getRefTypeName(node.name);
         const refTypeDataProperty = objectTypeProperty(
           DATA_REF,
-          ts.createTypeReferenceNode(dataTypeName, undefined),
+          ts.factory.createTypeReferenceNode(dataTypeName, undefined),
           { optional: true }
         );
         // @ts-ignore
-        refTypeDataProperty.questionToken = ts.createToken(
+        refTypeDataProperty.questionToken = ts.factory.createToken(
           ts.SyntaxKind.QuestionToken
         );
         const refTypeFragmentRefProperty = objectTypeProperty(
           FRAGMENT_REFS,
-          ts.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [
-            ts.createLiteralTypeNode(ts.createStringLiteral(node.name)),
+          ts.factory.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [
+            ts.factory.createLiteralTypeNode(
+              ts.factory.createStringLiteral(node.name)
+            ),
           ])
         );
         const isPluralFragment = isPlural(node);
@@ -564,9 +586,10 @@ function createVisitor(
           unmasked ? undefined : node.name
         );
         const type = isPlural(node)
-          ? ts.createTypeReferenceNode(ts.createIdentifier("ReadonlyArray"), [
-              baseType,
-            ])
+          ? ts.factory.createTypeReferenceNode(
+              ts.factory.createIdentifier("ReadonlyArray"),
+              [baseType]
+            )
           : baseType;
         state.runtimeImports.add("FragmentRefs");
 
@@ -578,8 +601,8 @@ function createVisitor(
           exportType(
             refTypeName,
             isPluralFragment
-              ? ts.createTypeReferenceNode(
-                  ts.createIdentifier("ReadonlyArray"),
+              ? ts.factory.createTypeReferenceNode(
+                  ts.factory.createIdentifier("ReadonlyArray"),
                   [refType]
                 )
               : refType
@@ -710,7 +733,9 @@ function makeRawResponseProp(
     );
   }
   if (schemaName === "__typename" && concreteType) {
-    value = ts.createLiteralTypeNode(ts.createLiteral(concreteType));
+    value = ts.factory.createLiteralTypeNode(
+      ts.factory.createStringLiteral(concreteType)
+    );
   } else if (nodeType) {
     value = transformScalarType(
       schema,
@@ -718,7 +743,7 @@ function makeRawResponseProp(
       state,
       selectionsToRawResponseBabel(
         schema,
-        [Array.from(nullthrows(nodeSelections).values())],
+        [Array.from(nullThrows(nodeSelections).values())],
         state,
         schema.isAbstractType(nodeType) || schema.isWrapper(nodeType)
           ? null
@@ -730,7 +755,9 @@ function makeRawResponseProp(
   const typeProperty = objectTypeProperty(key, value);
   if (conditional) {
     // @ts-ignore
-    typeProperty.questionToken = ts.createToken(ts.SyntaxKind.QuestionToken);
+    typeProperty.questionToken = ts.factory.createToken(
+      ts.SyntaxKind.QuestionToken
+    );
   }
 
   return typeProperty;
@@ -785,7 +812,7 @@ function selectionsToRawResponseBabel(
   if (Object.keys(byConcreteType).length) {
     const baseFieldsMap = selectionsToMap(baseFields);
     for (const concreteType in byConcreteType) {
-      const mergedSeletions = Array.from(
+      const mergedSelections = Array.from(
         mergeSelections(
           baseFieldsMap,
           selectionsToMap(byConcreteType[concreteType]),
@@ -794,12 +821,18 @@ function selectionsToRawResponseBabel(
       );
       types.push(
         exactObjectTypeAnnotation(
-          mergedSeletions.map((selection) =>
+          mergedSelections.map((selection) =>
             makeRawResponseProp(schema, selection, state, concreteType)
           )
         )
       );
-      appendLocal3DPayload(types, mergedSeletions, schema, state, concreteType);
+      appendLocal3DPayload(
+        types,
+        mergedSelections,
+        schema,
+        state,
+        concreteType
+      );
     }
   }
   if (baseFields.length > 0) {
@@ -812,7 +845,7 @@ function selectionsToRawResponseBabel(
     );
     appendLocal3DPayload(types, baseFields, schema, state, nodeTypeName);
   }
-  return ts.createUnionTypeNode(types);
+  return ts.factory.createUnionTypeNode(types);
 }
 
 function appendLocal3DPayload(
@@ -827,16 +860,19 @@ function appendLocal3DPayload(
     // Generate an extra opaque type for client 3D fields
     state.runtimeImports.add("Local3DPayload");
     types.push(
-      ts.createTypeReferenceNode(ts.createIdentifier("Local3DPayload"), [
-        stringLiteralTypeAnnotation(moduleImport.documentName!),
-        exactObjectTypeAnnotation(
-          selections
-            .filter((sel) => sel.schemaName !== "js")
-            .map((selection) =>
-              makeRawResponseProp(schema, selection, state, currentType)
-            )
-        ),
-      ])
+      ts.factory.createTypeReferenceNode(
+        ts.factory.createIdentifier("Local3DPayload"),
+        [
+          stringLiteralTypeAnnotation(moduleImport.documentName!),
+          exactObjectTypeAnnotation(
+            selections
+              .filter((sel) => sel.schemaName !== "js")
+              .map((selection) =>
+                makeRawResponseProp(schema, selection, state, currentType)
+              )
+          ),
+        ]
+      )
     );
   }
 }
@@ -1008,14 +1044,18 @@ function groupRefs(props: Selection[]): Selection[] {
   });
 
   if (refs.length > 0) {
-    const refTypes = ts.createUnionTypeNode(
-      refs.map((ref) => ts.createLiteralTypeNode(ts.createStringLiteral(ref)))
+    const refTypes = ts.factory.createUnionTypeNode(
+      refs.map((ref) =>
+        ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(ref))
+      )
     );
 
     result.push({
       key: FRAGMENT_REFS,
       conditional: false,
-      value: ts.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [refTypes]),
+      value: ts.factory.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [
+        refTypes,
+      ]),
     });
   }
 
@@ -1025,19 +1065,20 @@ function groupRefs(props: Selection[]): Selection[] {
 function getFragmentRefsTypeImport(state: State): ts.Statement[] {
   if (state.usedFragments.size > 0) {
     return [
-      ts.createImportDeclaration(
+      ts.factory.createImportDeclaration(
         undefined,
         undefined,
-        ts.createImportClause(
+        ts.factory.createImportClause(
+          false,
           undefined,
-          ts.createNamedImports([
-            ts.createImportSpecifier(
+          ts.factory.createNamedImports([
+            ts.factory.createImportSpecifier(
               undefined,
-              ts.createIdentifier("FragmentRefs")
+              ts.factory.createIdentifier("FragmentRefs")
             ),
           ])
         ),
-        ts.createStringLiteral("relay-runtime")
+        ts.factory.createStringLiteral("relay-runtime")
       ),
     ];
   }
@@ -1075,7 +1116,7 @@ function getEnumDefinitions(
 
     return exportType(
       name,
-      ts.createUnionTypeNode(
+      ts.factory.createUnionTypeNode(
         values.map((value) => stringLiteralTypeAnnotation(value))
       )
     );
@@ -1083,7 +1124,7 @@ function getEnumDefinitions(
 }
 
 function stringLiteralTypeAnnotation(name: string): ts.TypeNode {
-  return ts.createLiteralTypeNode(ts.createLiteral(name));
+  return ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(name));
 }
 
 function getRefTypeName(name: string): string {

--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -150,13 +150,9 @@ function makeProp(
       )
     );
   }
-  const typeProperty = objectTypeProperty(key, value);
-  if (conditional) {
-    // @ts-ignore
-    typeProperty.questionToken = ts.factory.createToken(
-      ts.SyntaxKind.QuestionToken
-    );
-  }
+  const typeProperty = objectTypeProperty(key, value, {
+    optional: conditional,
+  });
 
   return typeProperty;
 }
@@ -559,10 +555,7 @@ function createVisitor(
           ts.factory.createTypeReferenceNode(dataTypeName, undefined),
           { optional: true }
         );
-        // @ts-ignore
-        refTypeDataProperty.questionToken = ts.factory.createToken(
-          ts.SyntaxKind.QuestionToken
-        );
+
         const refTypeFragmentRefProperty = objectTypeProperty(
           FRAGMENT_REFS,
           ts.factory.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [
@@ -752,13 +745,9 @@ function makeRawResponseProp(
     );
   }
 
-  const typeProperty = objectTypeProperty(key, value);
-  if (conditional) {
-    // @ts-ignore
-    typeProperty.questionToken = ts.factory.createToken(
-      ts.SyntaxKind.QuestionToken
-    );
-  }
+  const typeProperty = objectTypeProperty(key, value, {
+    optional: conditional,
+  });
 
   return typeProperty;
 }

--- a/src/TypeScriptTypeTransformers.ts
+++ b/src/TypeScriptTypeTransformers.ts
@@ -35,10 +35,11 @@ export function transformScalarType(
       objectProps
     );
   } else {
-    return ts.createUnionTypeNode([
+    return ts.factory.createUnionTypeNode([
       transformNonNullableScalarType(schema, type, state, objectProps),
-      // @ts-ignore
-      ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword),
+      ts.factory.createLiteralTypeNode(
+        ts.factory.createToken(ts.SyntaxKind.NullKeyword)
+      ),
     ]);
   }
 }
@@ -50,14 +51,17 @@ function transformNonNullableScalarType(
   objectProps?: ts.TypeNode
 ): ts.TypeNode {
   if (schema.isList(type)) {
-    return ts.createTypeReferenceNode(ts.createIdentifier("ReadonlyArray"), [
-      transformScalarType(
-        schema,
-        schema.getListItemType(type),
-        state,
-        objectProps
-      ),
-    ]);
+    return ts.factory.createTypeReferenceNode(
+      ts.factory.createIdentifier("ReadonlyArray"),
+      [
+        transformScalarType(
+          schema,
+          schema.getListItemType(type),
+          state,
+          objectProps
+        ),
+      ]
+    );
   } else if (
     schema.isObject(type) ||
     schema.isUnion(type) ||
@@ -82,17 +86,17 @@ function transformGraphQLScalarType(
     case "ID":
     case "String":
     case "Url":
-      return ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
     case "Float":
     case "Int":
-      return ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
     case "Boolean":
-      return ts.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
+      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
 
     default:
       return customType
-        ? ts.createTypeReferenceNode(customType, undefined)
-        : ts.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
+        ? ts.factory.createTypeReferenceNode(customType, undefined)
+        : ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
   }
 }
 
@@ -102,8 +106,8 @@ function transformGraphQLEnumType(
   state: State
 ): ts.TypeNode {
   state.usedEnums[schema.getTypeString(type)] = type;
-  return ts.createTypeReferenceNode(
-    ts.createIdentifier(schema.getTypeString(type)),
+  return ts.factory.createTypeReferenceNode(
+    ts.factory.createIdentifier(schema.getTypeString(type)),
     []
   );
 }
@@ -120,10 +124,11 @@ export function transformInputType(
       state
     );
   } else {
-    return ts.createUnionTypeNode([
+    return ts.factory.createUnionTypeNode([
       transformNonNullableInputType(schema, type, state),
-      // @ts-ignore
-      ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword),
+      ts.factory.createLiteralTypeNode(
+        ts.factory.createToken(ts.SyntaxKind.NullKeyword)
+      ),
     ]);
   }
 }
@@ -134,9 +139,10 @@ function transformNonNullableInputType(
   state: State
 ) {
   if (schema.isList(type)) {
-    return ts.createTypeReferenceNode(ts.createIdentifier("Array"), [
-      transformInputType(schema, schema.getListItemType(type), state),
-    ]);
+    return ts.factory.createTypeReferenceNode(
+      ts.factory.createIdentifier("Array"),
+      [transformInputType(schema, schema.getListItemType(type), state)]
+    );
   } else if (schema.isScalar(type)) {
     return transformGraphQLScalarType(schema.getTypeString(type), state);
   } else if (schema.isEnum(type)) {
@@ -144,8 +150,8 @@ function transformNonNullableInputType(
   } else if (schema.isInputObject(type)) {
     const typeIdentifier = getInputObjectTypeIdentifier(schema, type);
     if (state.generatedInputObjectTypes[typeIdentifier]) {
-      return ts.createTypeReferenceNode(
-        ts.createIdentifier(typeIdentifier),
+      return ts.factory.createTypeReferenceNode(
+        ts.factory.createIdentifier(typeIdentifier),
         []
       );
     }
@@ -156,23 +162,25 @@ function transformNonNullableInputType(
     const props = fields.map((fieldID: FieldID) => {
       const fieldType = schema.getFieldType(fieldID);
       const fieldName = schema.getFieldName(fieldID);
-      const property = ts.createPropertySignature(
+      const property = ts.factory.createPropertySignature(
         undefined,
-        ts.createIdentifier(fieldName),
+        ts.factory.createIdentifier(fieldName),
         state.optionalInputFields.indexOf(fieldName) >= 0 ||
           !schema.isNonNull(fieldType)
-          ? ts.createToken(ts.SyntaxKind.QuestionToken)
+          ? ts.factory.createToken(ts.SyntaxKind.QuestionToken)
           : undefined,
-        transformInputType(schema, fieldType, state),
-        undefined
+        transformInputType(schema, fieldType, state)
       );
 
       return property;
     });
-    state.generatedInputObjectTypes[typeIdentifier] = ts.createTypeLiteralNode(
-      props
+    state.generatedInputObjectTypes[
+      typeIdentifier
+    ] = ts.factory.createTypeLiteralNode(props);
+    return ts.factory.createTypeReferenceNode(
+      ts.factory.createIdentifier(typeIdentifier),
+      []
     );
-    return ts.createTypeReferenceNode(ts.createIdentifier(typeIdentifier), []);
   } else {
     throw new Error(`Could not convert from GraphQL type ${type.toString()}`);
   }

--- a/src/TypeScriptTypeTransformers.ts
+++ b/src/TypeScriptTypeTransformers.ts
@@ -37,7 +37,8 @@ export function transformScalarType(
   } else {
     return ts.createUnionTypeNode([
       transformNonNullableScalarType(schema, type, state, objectProps),
-      ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword)
+      // @ts-ignore
+      ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword),
     ]);
   }
 }
@@ -55,7 +56,7 @@ function transformNonNullableScalarType(
         schema.getListItemType(type),
         state,
         objectProps
-      )
+      ),
     ]);
   } else if (
     schema.isObject(type) ||
@@ -121,7 +122,8 @@ export function transformInputType(
   } else {
     return ts.createUnionTypeNode([
       transformNonNullableInputType(schema, type, state),
-      ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword)
+      // @ts-ignore
+      ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword),
     ]);
   }
 }
@@ -133,7 +135,7 @@ function transformNonNullableInputType(
 ) {
   if (schema.isList(type)) {
     return ts.createTypeReferenceNode(ts.createIdentifier("Array"), [
-      transformInputType(schema, schema.getListItemType(type), state)
+      transformInputType(schema, schema.getListItemType(type), state),
     ]);
   } else if (schema.isScalar(type)) {
     return transformGraphQLScalarType(schema.getTypeString(type), state);

--- a/src/addAnyTypeCast.ts
+++ b/src/addAnyTypeCast.ts
@@ -5,9 +5,9 @@ export default function addAsAnyToObjectLiterals(oldSource: string): string {
     return function transform(rootNode: T) {
       function visit(node: ts.Node): ts.Node {
         if (node.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-          return ts.createAsExpression(
+          return ts.factory.createAsExpression(
             node as ts.Expression,
-            ts.createTypeReferenceNode("any", [])
+            ts.factory.createTypeReferenceNode("any", [])
           );
         }
         return ts.visitEachChild(node, visit, context);
@@ -27,7 +27,7 @@ export default function addAsAnyToObjectLiterals(oldSource: string): string {
   const result = ts.transform(source, [transformer]);
 
   const printer: ts.Printer = ts.createPrinter({
-    newLine: ts.NewLineKind.LineFeed
+    newLine: ts.NewLineKind.LineFeed,
   });
   return printer.printFile(result.transformed[0] as ts.SourceFile);
 }

--- a/test/FindGraphQLTags-test.ts
+++ b/test/FindGraphQLTags-test.ts
@@ -21,7 +21,7 @@ describe("FindGraphQLTags", () => {
     ).toEqual([
       {
         keyName: null,
-        template: `
+        template: /* GraphQL */ `
           fragment TestModule_artist on Artist {
             name
           }

--- a/test/FindGraphQLTags-test.ts
+++ b/test/FindGraphQLTags-test.ts
@@ -1,7 +1,7 @@
 import * as FindGraphQLTags from "../src/FindGraphQLTags";
 
 describe("FindGraphQLTags", () => {
-  function find(text) {
+  function find(text: string) {
     return FindGraphQLTags.find(text, "/path/to/TestModule.ts");
   }
 

--- a/test/TypeScriptGenerator-test.ts
+++ b/test/TypeScriptGenerator-test.ts
@@ -1,13 +1,9 @@
-import { CompilerContext, IRTransforms, Root } from "relay-compiler";
-// @ts-ignore
+import { CompilerContext, IRTransforms, Root,  } from "relay-compiler";
 import { TypeGeneratorOptions } from "relay-compiler/lib/language/RelayLanguagePluginInterface";
-// @ts-ignore
 import { generateTestsFromFixtures } from "relay-test-utils-internal/lib/generateTestsFromFixtures";
-// @ts-ignore
-import * as parseGraphQLText from "relay-test-utils-internal/lib/parseGraphQLText";
-// @ts-ignore
 import { TestSchema } from "relay-test-utils-internal/lib/TestSchema";
 import * as TypeScriptGenerator from "../src/TypeScriptGenerator";
+import parseGraphQLText = require("relay-test-utils-internal/lib/parseGraphQLText");
 
 function generate(
   text: string,
@@ -16,7 +12,7 @@ function generate(
 ) {
   const schema = TestSchema.extend([
     ...IRTransforms.schemaExtensions,
-    `
+    /* GraphQL */ `
       scalar Color
       extend type User {
         color: Color

--- a/test/TypeScriptGenerator-test.ts
+++ b/test/TypeScriptGenerator-test.ts
@@ -1,12 +1,16 @@
 import { CompilerContext, IRTransforms, Root } from "relay-compiler";
+// @ts-ignore
 import { TypeGeneratorOptions } from "relay-compiler/lib/language/RelayLanguagePluginInterface";
+// @ts-ignore
 import { generateTestsFromFixtures } from "relay-test-utils-internal/lib/generateTestsFromFixtures";
+// @ts-ignore
 import * as parseGraphQLText from "relay-test-utils-internal/lib/parseGraphQLText";
+// @ts-ignore
 import { TestSchema } from "relay-test-utils-internal/lib/TestSchema";
 import * as TypeScriptGenerator from "../src/TypeScriptGenerator";
 
 function generate(
-  text,
+  text: string,
   options: TypeGeneratorOptions,
   context?: CompilerContext
 ) {
@@ -65,7 +69,7 @@ function generate(
 }
 
 describe("Snapshot tests", () => {
-  function generateContext(text) {
+  function generateContext(text: string) {
     const relaySchema = TestSchema.extend(IRTransforms.schemaExtensions);
     const { definitions, schema: extendedSchema } = parseGraphQLText(
       relaySchema,
@@ -81,7 +85,7 @@ describe("Snapshot tests", () => {
   }
 
   describe("TypeScriptGenerator with a single artifact directory", () => {
-    generateTestsFromFixtures(`${__dirname}/fixtures/type-generator`, text => {
+    generateTestsFromFixtures(`${__dirname}/fixtures/type-generator`, (text: string) => {
       const context = generateContext(text);
       return generate(
         text,
@@ -100,7 +104,7 @@ describe("Snapshot tests", () => {
   });
 
   describe("TypeScriptGenerator without a single artifact directory", () => {
-    generateTestsFromFixtures(`${__dirname}/fixtures/type-generator`, text => {
+    generateTestsFromFixtures(`${__dirname}/fixtures/type-generator`, (text: string) => {
       const context = generateContext(text);
       return generate(
         text,

--- a/test/TypeScriptGenerator-test.ts
+++ b/test/TypeScriptGenerator-test.ts
@@ -1,9 +1,9 @@
 import { CompilerContext, IRTransforms, Root,  } from "relay-compiler";
 import { TypeGeneratorOptions } from "relay-compiler/lib/language/RelayLanguagePluginInterface";
 import { generateTestsFromFixtures } from "relay-test-utils-internal/lib/generateTestsFromFixtures";
+import parseGraphQLText = require("relay-test-utils-internal/lib/parseGraphQLText");
 import { TestSchema } from "relay-test-utils-internal/lib/TestSchema";
 import * as TypeScriptGenerator from "../src/TypeScriptGenerator";
-import parseGraphQLText = require("relay-test-utils-internal/lib/parseGraphQLText");
 
 function generate(
   text: string,

--- a/test/__snapshots__/TypeScriptGenerator-test.ts.snap
+++ b/test/__snapshots__/TypeScriptGenerator-test.ts.snap
@@ -884,7 +884,7 @@ exports[`Snapshot tests TypeScriptGenerator with a single artifact directory mat
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation AppendEdgeMutation(
   $input: CommentCreateInput!,
-  $connections: [String!]!
+  $connections: [ID!]!
 )  {
   commentCreate(input: $input) {
     feedbackCommentEdge @appendEdge(connections: $connections) {
@@ -898,7 +898,7 @@ mutation AppendEdgeMutation(
 
 mutation PrependEdgeMutation(
   $input: CommentCreateInput!,
-  $connections: [String!]!
+  $connections: [ID!]!
 )  {
   commentCreate(input: $input) {
     feedbackCommentEdge @prependEdge(connections: $connections) {
@@ -3418,7 +3418,7 @@ exports[`Snapshot tests TypeScriptGenerator without a single artifact directory 
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation AppendEdgeMutation(
   $input: CommentCreateInput!,
-  $connections: [String!]!
+  $connections: [ID!]!
 )  {
   commentCreate(input: $input) {
     feedbackCommentEdge @appendEdge(connections: $connections) {
@@ -3432,7 +3432,7 @@ mutation AppendEdgeMutation(
 
 mutation PrependEdgeMutation(
   $input: CommentCreateInput!,
-  $connections: [String!]!
+  $connections: [ID!]!
 )  {
   commentCreate(input: $input) {
     feedbackCommentEdge @prependEdge(connections: $connections) {

--- a/test/ambient.d.ts
+++ b/test/ambient.d.ts
@@ -4,3 +4,20 @@ declare namespace jest {
     toMatchFile(width: string): void;
   }
 }
+
+
+declare module "relay-test-utils-internal/lib/generateTestsFromFixtures" {
+
+  export function generateTestsFromFixtures(path: string, callback: (text: string) => void): void
+}
+
+declare module "relay-test-utils-internal/lib/parseGraphQLText" {
+  import type {Fragment, Root, Schema} from 'relay-compiler';
+  function parseGraphQLText(schema: Schema, text: string): { definitions: ReadonlyArray<Fragment | Root>, schema: Schema }
+  export = parseGraphQLText
+}
+
+declare module "relay-test-utils-internal/lib/TestSchema" {
+  import type {Schema} from 'relay-compiler';
+  export const TestSchema: Schema
+}

--- a/test/fixtures/type-generator/mutation-with-append-prepend-edge.graphql
+++ b/test/fixtures/type-generator/mutation-with-append-prepend-edge.graphql
@@ -1,6 +1,6 @@
 mutation AppendEdgeMutation(
   $input: CommentCreateInput!,
-  $connections: [String!]!
+  $connections: [ID!]!
 )  {
   commentCreate(input: $input) {
     feedbackCommentEdge @appendEdge(connections: $connections) {
@@ -14,7 +14,7 @@ mutation AppendEdgeMutation(
 
 mutation PrependEdgeMutation(
   $input: CommentCreateInput!,
-  $connections: [String!]!
+  $connections: [ID!]!
 )  {
   commentCreate(input: $input) {
     feedbackCommentEdge @prependEdge(connections: $connections) {

--- a/test/formatGeneratedModule-test.ts
+++ b/test/formatGeneratedModule-test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 
-import * as diff from "jest-diff";
+import diff from "jest-diff";
 
 import { formatterFactory } from "../src/formatGeneratedModule";
 
@@ -41,6 +41,7 @@ describe("formatGeneratedModule", () => {
     expect(
       formatGeneratedModule({
         moduleName: "complete-example",
+        // @ts-ignore
         documentType: "ConcreteFragment",
         docText: null,
         concreteText: JSON.stringify({ the: { fragment: { data: 42 } } }),
@@ -49,6 +50,7 @@ describe("formatGeneratedModule", () => {
         relayRuntimeModule: "relay-runtime",
         sourceHash: "edcba"
       })
+      // @ts-ignore
     ).toMatchFile(
       join(__dirname, "fixtures/generated-module/complete-example.ts")
     );
@@ -59,6 +61,7 @@ describe("formatGeneratedModule", () => {
     expect(
       formatGeneratedModule({
         moduleName: "complete-example",
+         // @ts-ignore
         documentType: "ConcreteFragment",
         docText: null,
         concreteText: JSON.stringify({ the: { fragment: { data: 42 } } }),
@@ -66,6 +69,7 @@ describe("formatGeneratedModule", () => {
         hash: "@relayHash abcde",
         sourceHash: "edcba"
       })
+       // @ts-ignore
     ).toMatchFile(
       join(__dirname, "fixtures/generated-module/complete-example.ts")
     );
@@ -76,6 +80,7 @@ describe("formatGeneratedModule", () => {
     expect(
       formatGeneratedModule({
         moduleName: "complete-example",
+         // @ts-ignore
         documentType: "ConcreteFragment",
         docText: null,
         concreteText: JSON.stringify({ the: { fragment: { data: 42 } } }),
@@ -83,6 +88,7 @@ describe("formatGeneratedModule", () => {
         hash: null,
         sourceHash: "edcba"
       })
+       // @ts-ignore
     ).toMatchFile(
       join(__dirname, "fixtures/generated-module/complete-example-no-cast.ts")
     );

--- a/test/formatGeneratedModule-test.ts
+++ b/test/formatGeneratedModule-test.ts
@@ -47,8 +47,7 @@ describe("formatGeneratedModule", () => {
         concreteText: JSON.stringify({ the: { fragment: { data: 42 } } }),
         typeText: "export type CompleteExample = { readonly id: string }",
         hash: "@relayHash abcde",
-        relayRuntimeModule: "relay-runtime",
-        sourceHash: "edcba"
+        sourceHash: "edcba",
       })
     ).toMatchFile(
       join(__dirname, "fixtures/generated-module/complete-example.ts")
@@ -60,13 +59,13 @@ describe("formatGeneratedModule", () => {
     expect(
       formatGeneratedModule({
         moduleName: "complete-example",
-         // @ts-ignore
+        // @ts-ignore
         documentType: "ConcreteFragment",
         docText: null,
         concreteText: JSON.stringify({ the: { fragment: { data: 42 } } }),
         typeText: "export type CompleteExample = { readonly id: string }",
         hash: "@relayHash abcde",
-        sourceHash: "edcba"
+        sourceHash: "edcba",
       })
     ).toMatchFile(
       join(__dirname, "fixtures/generated-module/complete-example.ts")
@@ -78,13 +77,13 @@ describe("formatGeneratedModule", () => {
     expect(
       formatGeneratedModule({
         moduleName: "complete-example",
-         // @ts-ignore
+        // @ts-ignore
         documentType: "ConcreteFragment",
         docText: null,
         concreteText: JSON.stringify({ the: { fragment: { data: 42 } } }),
         typeText: "export type CompleteExample = { readonly id: string }",
         hash: null,
-        sourceHash: "edcba"
+        sourceHash: "edcba",
       })
     ).toMatchFile(
       join(__dirname, "fixtures/generated-module/complete-example-no-cast.ts")

--- a/test/formatGeneratedModule-test.ts
+++ b/test/formatGeneratedModule-test.ts
@@ -50,7 +50,6 @@ describe("formatGeneratedModule", () => {
         relayRuntimeModule: "relay-runtime",
         sourceHash: "edcba"
       })
-      // @ts-ignore
     ).toMatchFile(
       join(__dirname, "fixtures/generated-module/complete-example.ts")
     );
@@ -69,7 +68,6 @@ describe("formatGeneratedModule", () => {
         hash: "@relayHash abcde",
         sourceHash: "edcba"
       })
-       // @ts-ignore
     ).toMatchFile(
       join(__dirname, "fixtures/generated-module/complete-example.ts")
     );
@@ -88,7 +86,6 @@ describe("formatGeneratedModule", () => {
         hash: null,
         sourceHash: "edcba"
       })
-       // @ts-ignore
     ).toMatchFile(
       join(__dirname, "fixtures/generated-module/complete-example-no-cast.ts")
     );

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["./test/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,5 +53,5 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "include": ["./src/**/*", "./types/**/*"]
+  "include": ["./src/**/*", "./types/**/*", "./test/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,6 +571,13 @@
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/runtime@7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
+  integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.7.tgz#194769ca8d6d7790ec23605af9ee3e42a0aa79cf"
@@ -3886,6 +3893,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
a lot of dependency updates got merged despite the build failing.

I tried to hotfix most things with ts-ignores, as well as breaking changes connections String -> ID.

Things are still far away from being optimal, but at least the build should not fail anymore...
