### PR TITLE
fix: revert breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 on:
   push:
+  pull_request:
 jobs:
   ci:
     name: Continuous Integration

--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -51,7 +51,7 @@ export const generate: TypeGenerator["generate"] = (schema, node, options) => {
   const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 
   const resultFile = ts.createSourceFile(
-    "grapghql-def.ts",
+    "graphql-def.ts",
     "",
     ts.ScriptTarget.Latest,
     false,

--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -150,9 +150,13 @@ function makeProp(
       )
     );
   }
-  const typeProperty = objectTypeProperty(key, value, {
-    optional: conditional,
-  });
+  const typeProperty = objectTypeProperty(key, value);
+  if (conditional) {
+    // @ts-ignore
+    typeProperty.questionToken = ts.factory.createToken(
+      ts.SyntaxKind.QuestionToken
+    );
+  }
 
   return typeProperty;
 }
@@ -555,7 +559,10 @@ function createVisitor(
           ts.factory.createTypeReferenceNode(dataTypeName, undefined),
           { optional: true }
         );
-
+        // @ts-ignore
+        refTypeDataProperty.questionToken = ts.factory.createToken(
+          ts.SyntaxKind.QuestionToken
+        );
         const refTypeFragmentRefProperty = objectTypeProperty(
           FRAGMENT_REFS,
           ts.factory.createTypeReferenceNode(FRAGMENT_REFS_TYPE_NAME, [
@@ -745,9 +752,13 @@ function makeRawResponseProp(
     );
   }
 
-  const typeProperty = objectTypeProperty(key, value, {
-    optional: conditional,
-  });
+  const typeProperty = objectTypeProperty(key, value);
+  if (conditional) {
+    // @ts-ignore
+    typeProperty.questionToken = ts.factory.createToken(
+      ts.SyntaxKind.QuestionToken
+    );
+  }
 
   return typeProperty;
 }

--- a/src/addAnyTypeCast.ts
+++ b/src/addAnyTypeCast.ts
@@ -5,9 +5,9 @@ export default function addAsAnyToObjectLiterals(oldSource: string): string {
     return function transform(rootNode: T) {
       function visit(node: ts.Node): ts.Node {
         if (node.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-          return ts.factory.createAsExpression(
+          return ts.createAsExpression(
             node as ts.Expression,
-            ts.factory.createTypeReferenceNode("any", [])
+            ts.createTypeReferenceNode("any", [])
           );
         }
         return ts.visitEachChild(node, visit, context);
@@ -27,7 +27,7 @@ export default function addAsAnyToObjectLiterals(oldSource: string): string {
   const result = ts.transform(source, [transformer]);
 
   const printer: ts.Printer = ts.createPrinter({
-    newLine: ts.NewLineKind.LineFeed,
+    newLine: ts.NewLineKind.LineFeed
   });
   return printer.printFile(result.transformed[0] as ts.SourceFile);
 }


### PR DESCRIPTION
This reverts the breaking changes I did in https://github.com/relay-tools/relay-compiler-language-typescript/pull/267 which broke Typescript < 4 support in 13.0.3 in a patch release :( (https://github.com/relay-tools/relay-compiler-language-typescript/issues/272).

We wanna release this as 13.0.5 then do a major release (14.0.0), which drops typescript < 4 support.

@alloy It seems like Travis CI automatically creates a release on every push on `master`. Could you explain how I could achieve a major version release? Is it based on commit messages? Maybe we should add a small contribution guide that explains how the deployment/changelog/versioning is done?

**Edit:** I just figured out this repo is using `auto`. Can you confirm that assigning the labels will trigger the right version bump being made? https://intuit.github.io/auto/docs/welcome/getting-started