### PR TITLE
feat: include .d.ts types in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     }
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "allowJs": true /* Allow javascript files to be compiled. */,
     "checkJs": false /* Report errors in .js files. */,
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./lib" /* Redirect output structure to the directory. */,


### PR DESCRIPTION
As I mentioned in #305 I was using this library as a foundation for another compiler specific to next.js - noticed the types were missing, figured it couldn't hurt to output them.