### PR TITLE
Remove artsy auto-config dep, update auto pinned version

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,5 +1,45 @@
 {
-  "extends": "@artsy",
   "name": "Eloy Durán",
   "email": "eloy.de.enige@gmail.com",
+  "labels": [
+    {
+      "name": "Version: Major",
+      "changelogTitle": "💥 Breaking Change",
+      "description": "Increment the major version when merged",
+      "releaseType": "major"
+    },
+    {
+      "name": "Version: Minor",
+      "changelogTitle": "🚀 Enhancement",
+      "description": "Increment the minor version when merged",
+      "releaseType": "minor"
+    },
+    {
+      "name": "Version: Patch",
+      "changelogTitle": "🐛 Bug Fix",
+      "description": "Increment the patch version when merged",
+      "releaseType": "patch"
+    },
+    {
+      "name": "Skip Release",
+      "description": "Preserve the current version when merged",
+      "releaseType": "skip"
+    },
+    {
+      "name": "Version: Trivial",
+      "changelogTitle": "🏠 Internal",
+      "description": "Changes only affect the internal API",
+      "releaseType": "none"
+    },
+    {
+      "name": "Docs",
+      "changelogTitle": "📝 Documentation",
+      "description": "Changes only affect the documentation",
+      "releaseType": "none"
+    }
+  ],
+  "plugins": [
+    "npm",
+    "released"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "invariant": "^2.2.4"
   },
   "devDependencies": {
-    "@artsy/auto-config": "^1.0.0",
     "@babel/runtime": "7.12.13",
     "@types/graphql": "^14.2.3",
     "@types/invariant": "2.2.34",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,5 @@
 if [ ! -z "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
-  npx auto@$AUTO_VERSION shipit $AUTO_OPTS
+  npx auto@v10.24.1 shipit -v
 else
   echo "Not on master, skipping deploy"
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@artsy/auto-config@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.0.2.tgz#b79f6fd0d0bda0c5e0764ced55e014cf58174d6f"
-  integrity sha512-mJyuKNDMYZcgc2oLIkvmpVIr1RexklV71JmU+to5qs3Y9pv5dsj4WHl8+wf9g74EQNOyhWH2SYMGBm1JoPYh/Q==
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"


### PR DESCRIPTION
This fixes the issues encountered in https://github.com/relay-tools/relay-compiler-language-typescript/pull/275 where the deploy failed to increment the correct version.

I've implemented both fixes I suggested in the above issue. We both remove our dependency from Artsy's auto config (which lead to this original breakage) and bump the version of auto. 

As a validation of this process, I've added the Trivial label which means this build should generate no release. 