### PR TITLE
Resolve `basePath` parameter to prevent errors when loading compiler options

### DIFF
--- a/src/loadCompilerOptions.ts
+++ b/src/loadCompilerOptions.ts
@@ -13,7 +13,7 @@ export const loadCompilerOptions = (): ts.CompilerOptions => {
   const parsedConfig = ts.parseJsonConfigFileContent(
     configFile.config,
     ts.sys,
-    "./"
+    ts.sys.resolvePath('./')
   );
   if (parsedConfig.errors.length > 0) {
     return {};


### PR DESCRIPTION
This PR resolves the relative `basePath` parameter passed to `ts.parseJsonConfigFileContent()`.

## Background
Despite setting the correct `target` and `module` versions in `tsconfig.json`, the `replaceRequire` option was never being set.

As it turned out, `loadCompilerOptions` was failing to parse our `tsconfig.json` correctly - the following error was causing it to return an empty object (despite the parsed config having a valid `options` property):

```
{
    file: undefined,
    start: undefined,
    length: undefined,
    messageText: `No inputs were found in config file 'tsconfig.json'. Specified 'include' paths were '["**/*"]' and 'exclude' paths were '["dist"]'.`,
    category: 1,
    code: 18003,
    reportsUnnecessary: undefined,
    reportsDeprecated: undefined
  }
```

We don't explicitly specify the `files` or `include` keys in `tsconfig.json`, which produces the default behavior of including all files in the current directory and subdirectory. Of course, we don't see the above error in any other circumstance - only `relay-compiler-typescript`'s `loadCompilerOptions` method.

Passing the relative path string`'./'` (existing behavior) produces an empty `files` array. This is because the relative path gets passed all the way through to TS's `getNormalizedAbsolutePath()`, which seems to expect an absolute path itself. When given a relative path, it produces a path string which causes no files to be resolved.

## Resolution
Resolving the path using `ts.sys.resolvePath('./')` results in our `files` array being populated correctly, the above error not being (silently) emitted, and things downstream working properly (module numbers being loaded from config, and `replaceRequire` being set accordingly).