### PR TITLE
[Chore] add note that this repository is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Obsolete
+
+This is repository is obsolete as [relay@13](https://github.com/facebook/relay/releases/tag/v13.0.0) now supports TypeScript directly.
+
 # relay-compiler-language-typescript
 
 [![Build Status](https://travis-ci.org/relay-tools/relay-compiler-language-typescript.svg?branch=master)](https://travis-ci.org/relay-tools/relay-compiler-language-typescript)


### PR DESCRIPTION
Add note to `README.md` that this repository is obsolete.

After merging the following steps are required:

- [ ] Add `[Obsolete]` to description
- [ ] Add `obsolete` tag
- [ ] Archive this repository
- [ ] Mark the package on [npm as depreacted](https://docs.npmjs.com/cli/v8/commands/npm-deprecate)

#581 